### PR TITLE
fix(security): update Docker base image for npm CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for efficient container size
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 # Build arguments
 ARG VERSION="unknown"
@@ -22,7 +22,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM node:20-alpine AS production
+FROM node:22-alpine AS production
 
 # Create a non-root user for security
 RUN addgroup -g 1001 -S autotask && \


### PR DESCRIPTION
## Summary
- Updates Docker base image from `node:20-alpine` to `node:22-alpine`
- Fixes CVE-2025-64756 (glob command injection vulnerability in npm)
- Fixes CVE-2024-21538 (cross-spawn ReDoS vulnerability in npm)

## Test plan
- [ ] Verify Docker image builds successfully with `docker build .`
- [ ] Confirm npm audit shows no high/critical vulnerabilities
- [ ] Test MCP server starts and responds to health checks

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates container base to Node 22.
> 
> - Switches `Dockerfile` builder and production stages from `node:20-alpine` to `node:22-alpine`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efcba4f7664bdffa16c44e4302fd9a2a36e421c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->