### PR TITLE
feat: Regular Time entry support with name resolution

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -523,21 +523,33 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   // Time entry tools
   {
     name: 'autotask_create_time_entry',
-    description: 'Create a time entry in Autotask',
+    description: 'Create a time entry in Autotask. Can be tied to a ticket, task, or project, OR created as "Regular Time" (no parent) for meetings, admin work, etc. For Regular Time, specify a category like "Internal Meeting", "Office Management", "Training", etc.',
     inputSchema: {
       type: 'object',
       properties: {
         ticketID: {
           type: 'number',
-          description: 'Ticket ID for the time entry'
+          description: 'Ticket ID for the time entry (omit for Regular Time)'
         },
         taskID: {
           type: 'number',
-          description: 'Task ID for the time entry (optional, for project work)'
+          description: 'Task ID for the time entry (for project work, omit for Regular Time)'
+        },
+        projectID: {
+          type: 'number',
+          description: 'Project ID for the time entry (omit for Regular Time)'
         },
         resourceID: {
           type: 'number',
-          description: 'Resource ID (user) logging the time'
+          description: 'Resource ID (user) logging the time. Can be omitted if resourceName is provided.'
+        },
+        resourceName: {
+          type: 'string',
+          description: 'Name of the resource/user (e.g., "Will Spence"). Will be resolved to a resourceID automatically. Use this instead of resourceID for convenience.'
+        },
+        category: {
+          type: 'string',
+          description: 'Category name for Regular Time entries (e.g., "Internal Meeting", "Office Management", "Training", "Research", "HR/Recruiting", "Travel Time", "Holiday", "PTO"). Required for Regular Time entries (when no ticket/task/project is specified).'
         },
         dateWorked: {
           type: 'string',
@@ -564,7 +576,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           description: 'Internal notes for the time entry'
         }
       },
-      required: ['resourceID', 'dateWorked', 'hoursWorked', 'summaryNotes']
+      required: ['dateWorked', 'hoursWorked', 'summaryNotes']
     }
   },
 

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -850,6 +850,37 @@ export class AutotaskToolHandler {
 
       // Time entries
       ['autotask_create_time_entry', async (a) => {
+        // If no resource specified at all, prompt the user
+        if (!a.resourceID && !a.resourceName) {
+          return { result: null, message: 'Please specify who is logging this time. Provide a resourceName (e.g., "Will Spence") or resourceID.' };
+        }
+        // Resolve resourceName to resourceID via SDK helper
+        if (a.resourceName && !a.resourceID) {
+          const resource = await s.resolveResourceByName(a.resourceName);
+          if (!resource) {
+            throw new Error(`No resource found matching "${a.resourceName}"`);
+          }
+          a.resourceID = resource.id;
+          delete a.resourceName;
+        }
+        // For Regular Time entries (no ticket/task/project), handle category
+        const isRegularTime = !a.ticketID && !a.taskID && !a.projectID;
+        if (isRegularTime) {
+          if (!a.category && !a.internalBillingCodeID) {
+            // List available categories and prompt user
+            const categories = await s.getInternalBillingCodeNames();
+            return { result: null, message: `Please specify a category for this Regular Time entry. Available categories: ${categories.join(', ')}` };
+          }
+          if (a.category && !a.internalBillingCodeID) {
+            const billingCode = await s.resolveInternalBillingCodeByName(a.category);
+            if (!billingCode) {
+              const categories = await s.getInternalBillingCodeNames();
+              throw new Error(`No category found matching "${a.category}". Available categories: ${categories.join(', ')}`);
+            }
+            a.internalBillingCodeID = billingCode.id;
+            delete a.category;
+          }
+        }
         const id = await s.createTimeEntry(a); return { result: id, message: `Successfully created time entry with ID: ${id}` };
       }],
 

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -619,31 +619,70 @@ export class AutotaskService {
   // Time entry operations
   async createTimeEntry(timeEntry: Partial<AutotaskTimeEntry>): Promise<number> {
     const client = await this.ensureClient();
-    
+
     try {
       this.logger.debug('Creating time entry:', timeEntry);
-      // autotask-node v2.1.0+ supports parent-child URL for ticket-scoped time entries
+      // Ticket-scoped time entries
       if (timeEntry.ticketID) {
         const response = await (client as any).timeEntries.create(timeEntry.ticketID, timeEntry);
-        const timeEntryId = response.data?.id;
+        const timeEntryId = response.data?.itemId || response.data?.id;
         this.logger.info(`Time entry created with ID: ${timeEntryId}`);
         return timeEntryId;
       }
-      // For task/project-scoped time entries, use direct axios call
-      let endpoint: string;
-      if (timeEntry.taskID) {
-        endpoint = `/Tasks/${timeEntry.taskID}/TimeEntries`;
-      } else if (timeEntry.projectID) {
-        endpoint = `/Projects/${timeEntry.projectID}/TimeEntries`;
-      } else {
-        throw new Error('Time entry must have a ticketID, taskID, or projectID');
+      // Task or project-scoped time entries
+      if (timeEntry.taskID || timeEntry.projectID) {
+        let endpoint: string;
+        if (timeEntry.taskID) {
+          endpoint = `/Tasks/${timeEntry.taskID}/TimeEntries`;
+        } else {
+          endpoint = `/Projects/${timeEntry.projectID}/TimeEntries`;
+        }
+        const response = await (client as any).axios.post(endpoint, timeEntry);
+        const timeEntryId = response.data?.itemId || response.data?.item?.id || response.data?.id;
+        this.logger.info(`Time entry created with ID: ${timeEntryId}`);
+        return timeEntryId;
       }
-      const response = await (client as any).axios.post(endpoint, timeEntry);
-      const timeEntryId = response.data?.item?.id || response.data?.id;
-      this.logger.info(`Time entry created with ID: ${timeEntryId}`);
+      // Regular Time entries (no parent - meetings, admin, etc.)
+      // Uses SDK's createRegularTimeEntry which handles timeEntryType and itemId
+      const timeEntryId = await (client as any).timeTracking.createRegularTimeEntry(timeEntry);
+      this.logger.info(`Regular time entry created with ID: ${timeEntryId}`);
       return timeEntryId;
     } catch (error) {
       this.logger.error('Failed to create time entry:', error);
+      throw error;
+    }
+  }
+
+  // Resource name resolution (delegates to SDK)
+  async resolveResourceByName(name: string): Promise<{ id: number; firstName: string; lastName: string } | null> {
+    const client = await this.ensureClient();
+    try {
+      return await (client as any).core.resolveResourceByName(name);
+    } catch (error) {
+      this.logger.error(`Failed to resolve resource "${name}":`, error);
+      throw error;
+    }
+  }
+
+  // Internal billing code helpers (delegates to SDK)
+  async getInternalBillingCodeNames(): Promise<string[]> {
+    const client = await this.ensureClient();
+    try {
+      const result = await (client as any).financial.getInternalBillingCodes();
+      const codes = (result.data as any[]) || [];
+      return codes.map((bc: any) => bc.name);
+    } catch (error) {
+      this.logger.error('Failed to get internal billing codes:', error);
+      throw error;
+    }
+  }
+
+  async resolveInternalBillingCodeByName(name: string): Promise<{ id: number; name: string } | null> {
+    const client = await this.ensureClient();
+    try {
+      return await (client as any).financial.resolveInternalBillingCodeByName(name);
+    } catch (error) {
+      this.logger.error(`Failed to resolve billing code "${name}":`, error);
       throw error;
     }
   }
@@ -2376,12 +2415,26 @@ export class AutotaskService {
 
   // BillingCode and Department entities are not directly available in autotask-node
   // These would need to be implemented via custom API calls or alternative endpoints
-  async getBillingCode(_id: number): Promise<AutotaskBillingCode | null> {
-    throw new Error('Billing codes API not directly available in autotask-node library');
+  async getBillingCode(id: number): Promise<AutotaskBillingCode | null> {
+    const client = await this.ensureClient();
+    try {
+      const result = await (client as any).financial.billingCodes.get(id);
+      return (result.data as AutotaskBillingCode) || null;
+    } catch (error) {
+      this.logger.error(`Failed to get billing code ${id}:`, error);
+      throw error;
+    }
   }
 
   async searchBillingCodes(_options: AutotaskQueryOptionsExtended = {}): Promise<AutotaskBillingCode[]> {
-    throw new Error('Billing codes API not directly available in autotask-node library');
+    const client = await this.ensureClient();
+    try {
+      const result = await (client as any).financial.getActiveBillingCodes();
+      return (result.data as AutotaskBillingCode[]) || [];
+    } catch (error) {
+      this.logger.error('Failed to search billing codes:', error);
+      throw error;
+    }
   }
 
   async getDepartment(_id: number): Promise<AutotaskDepartment | null> {


### PR DESCRIPTION
## Summary

- **Regular Time entries** — `autotask_create_time_entry` can now create time entries not tied to a ticket, task, or project (for meetings, admin work, training, etc.)
- **Name-based resolution** — accepts `resourceName` (e.g., "Will Spence") instead of requiring numeric `resourceID`
- **Category selection** — accepts `category` (e.g., "Internal Meeting") instead of requiring numeric `internalBillingCodeID`
- **Smart prompting** — when resource or category is missing, returns available options instead of failing
- **Billing code stubs implemented** — `searchBillingCodes()` and `getBillingCode()` now work instead of throwing "not available" errors

### Example usage in Claude Desktop:
> "Log 1 hour of regular time for Will Spence, internal meeting, summary: B and I meeting"

### Depends on
- wyre-technology/autotask-node#153 (SDK helpers for name resolution and Regular Time)

## Test plan

- [ ] Create Regular Time entry with `resourceName` + `category` (both resolved automatically)
- [ ] Verify prompting when no resource specified → lists prompt for name
- [ ] Verify prompting when no category specified → lists available categories (Internal Meeting, Training, PTO, etc.)
- [ ] Verify ticket-scoped time entries still work unchanged
- [ ] Verify task/project-scoped time entries still work unchanged
- [ ] Verify invalid resource name returns helpful error
- [ ] Verify invalid category name returns list of valid options

🤖 Generated with [Claude Code](https://claude.com/claude-code)