### PR TITLE
fix: resolve npm ci prefer-offline/online conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies (--ignore-scripts prevents 'prepare' from running before source is copied)
-RUN npm config delete prefer-offline && npm config delete prefer-online && npm ci --ignore-scripts
+RUN npm config set prefer-offline false && npm config set prefer-online false && npm ci --ignore-scripts
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
This PR addresses the CI failure in the Docker build by explicitly setting  before running 
added 1075 packages, and audited 1227 packages in 13s

213 packages are looking for funding
  run `npm fund` for details

26 vulnerabilities (12 low, 1 moderate, 13 high)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details. in the Dockerfile. This resolves the conflict where  and  were implicitly both set to false, causing the npm command to fail.