### PR TITLE
feat: add Service Call support (11 new tools)

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -1896,6 +1896,259 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     }
   },
 
+  // Service Call tools
+  {
+    name: 'autotask_search_service_calls',
+    description: 'Search for service calls in Autotask. Returns 25 results per page by default. Use page parameter for more results.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'number',
+          description: 'Filter by service call status ID'
+        },
+        startDate: {
+          type: 'string',
+          description: 'Filter service calls starting on or after this date (ISO format, e.g. 2026-01-01T00:00:00Z)'
+        },
+        endDate: {
+          type: 'string',
+          description: 'Filter service calls ending on or before this date (ISO format)'
+        },
+        page: {
+          type: 'number',
+          description: 'Page number for pagination (default: 1)',
+          minimum: 1
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Results per page (default: 25, max: 200)',
+          minimum: 1,
+          maximum: 200
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: 'autotask_get_service_call',
+    description: 'Get detailed information for a specific service call by ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Service call ID to retrieve'
+        }
+      },
+      required: ['id']
+    }
+  },
+  {
+    name: 'autotask_create_service_call',
+    description: 'Create a new service call in Autotask',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        description: {
+          type: 'string',
+          description: 'Service call description'
+        },
+        startDateTime: {
+          type: 'string',
+          description: 'Service call start date/time (ISO format, e.g. 2026-01-15T09:00:00Z)'
+        },
+        endDateTime: {
+          type: 'string',
+          description: 'Service call end date/time (ISO format)'
+        },
+        status: {
+          type: 'number',
+          description: 'Service call status ID'
+        },
+        duration: {
+          type: 'number',
+          description: 'Duration in hours'
+        }
+      },
+      required: ['description', 'startDateTime', 'endDateTime', 'status']
+    }
+  },
+  {
+    name: 'autotask_update_service_call',
+    description: 'Update an existing service call in Autotask',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Service call ID to update'
+        },
+        description: {
+          type: 'string',
+          description: 'Service call description'
+        },
+        startDateTime: {
+          type: 'string',
+          description: 'Service call start date/time (ISO format)'
+        },
+        endDateTime: {
+          type: 'string',
+          description: 'Service call end date/time (ISO format)'
+        },
+        status: {
+          type: 'number',
+          description: 'Service call status ID'
+        },
+        duration: {
+          type: 'number',
+          description: 'Duration in hours'
+        }
+      },
+      required: ['id']
+    }
+  },
+  {
+    name: 'autotask_delete_service_call',
+    description: 'Delete a service call from Autotask',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Service call ID to delete'
+        }
+      },
+      required: ['id']
+    }
+  },
+
+  // Service Call Ticket tools (link tickets to service calls)
+  {
+    name: 'autotask_search_service_call_tickets',
+    description: 'Search for ticket associations on service calls. Use to find which tickets are linked to a service call.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serviceCallId: {
+          type: 'number',
+          description: 'Filter by service call ID'
+        },
+        ticketId: {
+          type: 'number',
+          description: 'Filter by ticket ID'
+        },
+        page: {
+          type: 'number',
+          description: 'Page number for pagination (default: 1)',
+          minimum: 1
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Results per page (default: 25, max: 200)',
+          minimum: 1,
+          maximum: 200
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: 'autotask_create_service_call_ticket',
+    description: 'Link a ticket to a service call',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serviceCallID: {
+          type: 'number',
+          description: 'Service call ID to link the ticket to'
+        },
+        ticketID: {
+          type: 'number',
+          description: 'Ticket ID to link to the service call'
+        }
+      },
+      required: ['serviceCallID', 'ticketID']
+    }
+  },
+  {
+    name: 'autotask_delete_service_call_ticket',
+    description: 'Unlink a ticket from a service call',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Service call ticket link ID to delete'
+        }
+      },
+      required: ['id']
+    }
+  },
+
+  // Service Call Ticket Resource tools (assign resources to service call tickets)
+  {
+    name: 'autotask_search_service_call_ticket_resources',
+    description: 'Search for resource assignments on service call tickets. Use to find which technicians are assigned to a service call.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serviceCallTicketId: {
+          type: 'number',
+          description: 'Filter by service call ticket ID'
+        },
+        resourceId: {
+          type: 'number',
+          description: 'Filter by resource (technician) ID'
+        },
+        page: {
+          type: 'number',
+          description: 'Page number for pagination (default: 1)',
+          minimum: 1
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Results per page (default: 25, max: 200)',
+          minimum: 1,
+          maximum: 200
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: 'autotask_create_service_call_ticket_resource',
+    description: 'Assign a resource (technician) to a service call ticket',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        serviceCallTicketID: {
+          type: 'number',
+          description: 'Service call ticket ID to assign the resource to'
+        },
+        resourceID: {
+          type: 'number',
+          description: 'Resource (technician) ID to assign'
+        }
+      },
+      required: ['serviceCallTicketID', 'resourceID']
+    }
+  },
+  {
+    name: 'autotask_delete_service_call_ticket_resource',
+    description: 'Unassign a resource (technician) from a service call ticket',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Service call ticket resource assignment ID to delete'
+        }
+      },
+      required: ['id']
+    }
+  },
+
   // === Meta-tools for progressive discovery (lazy loading mode) ===
   {
     name: 'autotask_list_categories',
@@ -2254,7 +2507,12 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
     tools: ['autotask_get_company_note', 'autotask_search_company_notes', 'autotask_create_company_note']
   },
   service_calls: {
+<<<<<<< Updated upstream
     description: 'Create, update, and manage service calls, their linked tickets, and resource assignments',
     tools: ['autotask_get_service_call', 'autotask_search_service_calls', 'autotask_create_service_call', 'autotask_update_service_call', 'autotask_delete_service_call', 'autotask_search_service_call_tickets', 'autotask_create_service_call_ticket', 'autotask_delete_service_call_ticket', 'autotask_search_service_call_ticket_resources', 'autotask_create_service_call_ticket_resource', 'autotask_delete_service_call_ticket_resource']
+=======
+    description: 'Service call dispatching, ticket linking, and resource assignments',
+    tools: ['autotask_search_service_calls', 'autotask_get_service_call', 'autotask_create_service_call', 'autotask_update_service_call', 'autotask_delete_service_call', 'autotask_search_service_call_tickets', 'autotask_create_service_call_ticket', 'autotask_delete_service_call_ticket', 'autotask_search_service_call_ticket_resources', 'autotask_create_service_call_ticket_resource', 'autotask_delete_service_call_ticket_resource']
+>>>>>>> Stashed changes
   }
 };

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1057,6 +1057,47 @@ export class AutotaskToolHandler {
         await s.deleteQuoteItem(a.quoteId, a.quoteItemId); return { result: true, message: `Quote item ${a.quoteItemId} deleted successfully` };
       }],
 
+      // Service Calls
+      ['autotask_search_service_calls', async (a) => {
+        const r = await s.searchServiceCalls(a); return { result: r, message: `Found ${r.length} service calls` };
+      }],
+      ['autotask_get_service_call', async (a) => {
+        const r = await s.getServiceCall(a.id); return { result: r, message: 'Service call retrieved successfully' };
+      }],
+      ['autotask_create_service_call', async (a) => {
+        const id = await s.createServiceCall(a); return { result: id, message: `Successfully created service call with ID: ${id}` };
+      }],
+      ['autotask_update_service_call', async (a) => {
+        const { id, ...updates } = a;
+        await s.updateServiceCall(id, updates);
+        return { result: id, message: `Successfully updated service call ${id}` };
+      }],
+      ['autotask_delete_service_call', async (a) => {
+        await s.deleteServiceCall(a.id); return { result: true, message: `Service call ${a.id} deleted successfully` };
+      }],
+
+      // Service Call Tickets
+      ['autotask_search_service_call_tickets', async (a) => {
+        const r = await s.searchServiceCallTickets(a); return { result: r, message: `Found ${r.length} service call tickets` };
+      }],
+      ['autotask_create_service_call_ticket', async (a) => {
+        const id = await s.createServiceCallTicket(a); return { result: id, message: `Successfully linked ticket to service call with ID: ${id}` };
+      }],
+      ['autotask_delete_service_call_ticket', async (a) => {
+        await s.deleteServiceCallTicket(a.id); return { result: true, message: `Service call ticket link ${a.id} deleted successfully` };
+      }],
+
+      // Service Call Ticket Resources
+      ['autotask_search_service_call_ticket_resources', async (a) => {
+        const r = await s.searchServiceCallTicketResources(a); return { result: r, message: `Found ${r.length} service call ticket resources` };
+      }],
+      ['autotask_create_service_call_ticket_resource', async (a) => {
+        const id = await s.createServiceCallTicketResource(a); return { result: id, message: `Successfully assigned resource to service call ticket with ID: ${id}` };
+      }],
+      ['autotask_delete_service_call_ticket_resource', async (a) => {
+        await s.deleteServiceCallTicketResource(a.id); return { result: true, message: `Service call ticket resource ${a.id} unassigned successfully` };
+      }],
+
       // Picklist tools
       ['autotask_list_queues', async () => {
         const queues = await this.picklistCache.getQueues();

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -31,7 +31,10 @@ import {
   AutotaskQueryOptionsExtended,
   AutotaskBillingItem,
   AutotaskBillingItemApprovalLevel,
+<<<<<<< Updated upstream
   AutotaskTicketCharge,
+=======
+>>>>>>> Stashed changes
   AutotaskServiceCall,
   AutotaskServiceCallTicket,
   AutotaskServiceCallTicketResource
@@ -2051,6 +2054,228 @@ export class AutotaskService {
       return timeEntries;
     } catch (error) {
       this.logger.error('Failed to search time entries:', error);
+      throw error;
+    }
+  }
+
+  // =====================================================
+  // SERVICE CALLS - Dispatch and scheduling
+  // =====================================================
+
+  async getServiceCall(id: number): Promise<AutotaskServiceCall | null> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug(`Getting service call with ID: ${id}`);
+      const result = await client.serviceCalls.get(id);
+      return result.data as AutotaskServiceCall || null;
+    } catch (error) {
+      this.logger.error(`Failed to get service call ${id}:`, error);
+      throw error;
+    }
+  }
+
+  async searchServiceCalls(options: AutotaskQueryOptionsExtended = {}): Promise<AutotaskServiceCall[]> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug('Searching service calls with options:', options);
+      const filters: any[] = [];
+
+      if (options.status !== undefined) {
+        filters.push({ op: 'eq', field: 'status', value: options.status });
+      }
+      if (options.startDate) {
+        filters.push({ op: 'gte', field: 'startDateTime', value: options.startDate });
+      }
+      if (options.endDate) {
+        filters.push({ op: 'lte', field: 'endDateTime', value: options.endDate });
+      }
+
+      if (filters.length === 0) {
+        filters.push({ op: 'gte', field: 'id', value: 0 });
+      }
+
+      const pageSize = Math.min(options.pageSize || 25, 200);
+      const queryOptions: any = {
+        filter: filters,
+        pageSize,
+        ...(options.page && { page: options.page }),
+      };
+
+      const result = await client.serviceCalls.list(queryOptions);
+      const serviceCalls = (result.data as AutotaskServiceCall[]) || [];
+
+      this.logger.info(`Retrieved ${serviceCalls.length} service calls (page ${options.page || 1}, pageSize ${pageSize})`);
+      return serviceCalls;
+    } catch (error) {
+      this.logger.error('Failed to search service calls:', error);
+      throw error;
+    }
+  }
+
+  async createServiceCall(data: Partial<AutotaskServiceCall>): Promise<number> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug('Creating service call:', data);
+      const result = await client.serviceCalls.create(data as any);
+      const id = (result.data as any)?.itemId ?? (result.data as any)?.id;
+      this.logger.info(`Service call created with ID: ${id}`);
+      return id;
+    } catch (error) {
+      this.logger.error('Failed to create service call:', error);
+      throw error;
+    }
+  }
+
+  async updateServiceCall(id: number, updates: Partial<AutotaskServiceCall>): Promise<void> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug(`Updating service call ${id}:`, updates);
+      await client.serviceCalls.patch(id, updates as any);
+      this.logger.info(`Service call ${id} updated successfully`);
+    } catch (error) {
+      this.logger.error(`Failed to update service call ${id}:`, error);
+      throw error;
+    }
+  }
+
+  async deleteServiceCall(id: number): Promise<void> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug(`Deleting service call ${id}`);
+      await client.serviceCalls.delete(id);
+      this.logger.info(`Service call ${id} deleted`);
+    } catch (error) {
+      this.logger.error(`Failed to delete service call ${id}:`, error);
+      throw error;
+    }
+  }
+
+  // =====================================================
+  // SERVICE CALL TICKETS - Link tickets to service calls
+  // =====================================================
+
+  async searchServiceCallTickets(options: AutotaskQueryOptionsExtended = {}): Promise<AutotaskServiceCallTicket[]> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug('Searching service call tickets with options:', options);
+      const filters: any[] = [];
+
+      if ((options as any).serviceCallId !== undefined) {
+        filters.push({ op: 'eq', field: 'serviceCallID', value: (options as any).serviceCallId });
+      }
+      if ((options as any).ticketId !== undefined) {
+        filters.push({ op: 'eq', field: 'ticketID', value: (options as any).ticketId });
+      }
+
+      if (filters.length === 0) {
+        filters.push({ op: 'gte', field: 'id', value: 0 });
+      }
+
+      const pageSize = Math.min(options.pageSize || 25, 200);
+      const queryOptions: any = {
+        filter: filters,
+        pageSize,
+        ...(options.page && { page: options.page }),
+      };
+
+      const result = await client.serviceCallTickets.list(queryOptions);
+      const items = (result.data as AutotaskServiceCallTicket[]) || [];
+
+      this.logger.info(`Retrieved ${items.length} service call tickets (page ${options.page || 1}, pageSize ${pageSize})`);
+      return items;
+    } catch (error) {
+      this.logger.error('Failed to search service call tickets:', error);
+      throw error;
+    }
+  }
+
+  async createServiceCallTicket(data: Partial<AutotaskServiceCallTicket>): Promise<number> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug('Creating service call ticket:', data);
+      const result = await client.serviceCallTickets.create(data as any);
+      const id = (result.data as any)?.itemId ?? (result.data as any)?.id;
+      this.logger.info(`Service call ticket created with ID: ${id}`);
+      return id;
+    } catch (error) {
+      this.logger.error('Failed to create service call ticket:', error);
+      throw error;
+    }
+  }
+
+  async deleteServiceCallTicket(id: number): Promise<void> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug(`Deleting service call ticket ${id}`);
+      await client.serviceCallTickets.delete(id);
+      this.logger.info(`Service call ticket ${id} deleted`);
+    } catch (error) {
+      this.logger.error(`Failed to delete service call ticket ${id}:`, error);
+      throw error;
+    }
+  }
+
+  // =====================================================
+  // SERVICE CALL TICKET RESOURCES - Assign resources to service call tickets
+  // =====================================================
+
+  async searchServiceCallTicketResources(options: AutotaskQueryOptionsExtended = {}): Promise<AutotaskServiceCallTicketResource[]> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug('Searching service call ticket resources with options:', options);
+      const filters: any[] = [];
+
+      if ((options as any).serviceCallTicketId !== undefined) {
+        filters.push({ op: 'eq', field: 'serviceCallTicketID', value: (options as any).serviceCallTicketId });
+      }
+      if ((options as any).resourceId !== undefined) {
+        filters.push({ op: 'eq', field: 'resourceID', value: (options as any).resourceId });
+      }
+
+      if (filters.length === 0) {
+        filters.push({ op: 'gte', field: 'id', value: 0 });
+      }
+
+      const pageSize = Math.min(options.pageSize || 25, 200);
+      const queryOptions: any = {
+        filter: filters,
+        pageSize,
+        ...(options.page && { page: options.page }),
+      };
+
+      const result = await client.serviceCallTicketResources.list(queryOptions);
+      const items = (result.data as AutotaskServiceCallTicketResource[]) || [];
+
+      this.logger.info(`Retrieved ${items.length} service call ticket resources (page ${options.page || 1}, pageSize ${pageSize})`);
+      return items;
+    } catch (error) {
+      this.logger.error('Failed to search service call ticket resources:', error);
+      throw error;
+    }
+  }
+
+  async createServiceCallTicketResource(data: Partial<AutotaskServiceCallTicketResource>): Promise<number> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug('Creating service call ticket resource:', data);
+      const result = await client.serviceCallTicketResources.create(data as any);
+      const id = (result.data as any)?.itemId ?? (result.data as any)?.id;
+      this.logger.info(`Service call ticket resource created with ID: ${id}`);
+      return id;
+    } catch (error) {
+      this.logger.error('Failed to create service call ticket resource:', error);
+      throw error;
+    }
+  }
+
+  async deleteServiceCallTicketResource(id: number): Promise<void> {
+    const client = await this.ensureClient();
+    try {
+      this.logger.debug(`Deleting service call ticket resource ${id}`);
+      await client.serviceCallTicketResources.delete(id);
+      this.logger.info(`Service call ticket resource ${id} deleted`);
+    } catch (error) {
+      this.logger.error(`Failed to delete service call ticket resource ${id}:`, error);
       throw error;
     }
   }

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -458,6 +458,34 @@ export interface AutotaskBillingItemApprovalLevel {
   [key: string]: any;
 }
 
+export interface AutotaskServiceCall {
+  id?: number;
+  description?: string;
+  status?: number;
+  startDateTime?: string;
+  endDateTime?: string;
+  duration?: number;
+  createDateTime?: string;
+  canceledDateTime?: string;
+  cancelationNotice?: string;
+  lastModifiedDateTime?: string;
+  [key: string]: any;
+}
+
+export interface AutotaskServiceCallTicket {
+  id?: number;
+  serviceCallID?: number;
+  ticketID?: number;
+  [key: string]: any;
+}
+
+export interface AutotaskServiceCallTicketResource {
+  id?: number;
+  serviceCallTicketID?: number;
+  resourceID?: number;
+  [key: string]: any;
+}
+
 export interface AutotaskUserDefinedField {
   name: string;
   value: string;


### PR DESCRIPTION
## Summary

Implements full Service Call support as requested in #38. Adds 11 new MCP tools:

### Service Calls (CRUD)
- `autotask_search_service_calls` — search/list with status and date filters
- `autotask_get_service_call` — get details by ID
- `autotask_create_service_call` — create new service call
- `autotask_update_service_call` — update existing
- `autotask_delete_service_call` — delete

### Service Call ↔ Ticket Links
- `autotask_create_service_call_ticket` — link a ticket to a service call
- `autotask_delete_service_call_ticket` — unlink
- `autotask_search_service_call_tickets` — list tickets on a service call

### Service Call Ticket Resources (Technician Assignments)
- `autotask_create_service_call_ticket_resource` — assign resource to service call ticket
- `autotask_delete_service_call_ticket_resource` — unassign
- `autotask_search_service_call_ticket_resources` — list assignments

All tools leverage the existing autotask-node library which already had full ServiceCall entity support.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)