### PR TITLE
fix: task creation endpoint, ticket notes, field info + phase tools

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -1701,6 +1701,62 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     }
   },
 
+  // Phase tools
+  {
+    name: 'autotask_list_phases',
+    description: 'List phases for a project in Autotask',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectID: {
+          type: 'number',
+          description: 'Project ID to list phases for'
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Results per page (default: 25, max: 100)',
+          minimum: 1,
+          maximum: 100
+        }
+      },
+      required: ['projectID']
+    }
+  },
+  {
+    name: 'autotask_create_phase',
+    description: 'Create a new phase in an Autotask project',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectID: {
+          type: 'number',
+          description: 'Project ID for the phase'
+        },
+        title: {
+          type: 'string',
+          description: 'Phase title'
+        },
+        description: {
+          type: 'string',
+          description: 'Phase description'
+        },
+        startDate: {
+          type: 'string',
+          description: 'Phase start date (ISO format)'
+        },
+        dueDate: {
+          type: 'string',
+          description: 'Phase due date (ISO format)'
+        },
+        estimatedHours: {
+          type: 'number',
+          description: 'Estimated hours for the phase'
+        }
+      },
+      required: ['projectID', 'title']
+    }
+  },
+
   // Picklist / Queue tools
   {
     name: 'autotask_list_queues',
@@ -1737,7 +1793,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
       properties: {
         entityType: {
           type: 'string',
-          description: 'The Autotask entity type (e.g., "Tickets", "Companies", "Contacts", "Projects")'
+          description: 'The Autotask entity type (e.g., "Tickets", "Companies", "Contacts", "Projects", "ProjectTasks", "TicketNotes"). Note: project tasks use "ProjectTasks" (or "Tasks" which auto-maps). See Autotask REST API entity names.'
         },
         fieldName: {
           type: 'string',
@@ -2495,8 +2551,8 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
     tools: ['autotask_search_tickets', 'autotask_get_ticket_details', 'autotask_create_ticket', 'autotask_update_ticket', 'autotask_get_ticket_note', 'autotask_search_ticket_notes', 'autotask_create_ticket_note', 'autotask_get_ticket_attachment', 'autotask_search_ticket_attachments', 'autotask_get_ticket_charge', 'autotask_search_ticket_charges', 'autotask_create_ticket_charge', 'autotask_update_ticket_charge', 'autotask_delete_ticket_charge']
   },
   projects: {
-    description: 'Search and create projects, tasks, and project notes',
-    tools: ['autotask_search_projects', 'autotask_create_project', 'autotask_search_tasks', 'autotask_create_task', 'autotask_get_project_note', 'autotask_search_project_notes', 'autotask_create_project_note']
+    description: 'Search and create projects, tasks, phases, and project notes',
+    tools: ['autotask_search_projects', 'autotask_create_project', 'autotask_search_tasks', 'autotask_create_task', 'autotask_list_phases', 'autotask_create_phase', 'autotask_get_project_note', 'autotask_search_project_notes', 'autotask_create_project_note']
   },
   time_and_billing: {
     description: 'Time entries, billing items, and expense management',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -899,6 +899,14 @@ export class AutotaskToolHandler {
         const id = await s.createTask(taskData); return { result: id, message: `Successfully created task with ID: ${id}` };
       }],
 
+      // Phases
+      ['autotask_list_phases', async (a) => {
+        const r = await s.searchPhases(a.projectID, { pageSize: a.pageSize }); return { result: r, message: `Found ${r.length} phases` };
+      }],
+      ['autotask_create_phase', async (a) => {
+        const id = await s.createPhase(a); return { result: id, message: `Successfully created phase with ID: ${id}` };
+      }],
+
       // Notes (ticket/project/company)
       ['autotask_get_ticket_note', async (a) => {
         const r = await s.getTicketNote(a.ticketId, a.noteId); return { result: r, message: 'Ticket note retrieved successfully' };
@@ -907,7 +915,12 @@ export class AutotaskToolHandler {
         const r = await s.searchTicketNotes(a.ticketId, { pageSize: a.pageSize }); return { result: r, message: `Found ${r.length} ticket notes` };
       }],
       ['autotask_create_ticket_note', async (a) => {
-        const id = await s.createTicketNote(a.ticketId, { title: a.title, description: a.description, noteType: a.noteType, publish: a.publish });
+        const id = await s.createTicketNote(a.ticketId, {
+          title: a.title || 'Note',
+          description: a.description,
+          noteType: a.noteType ?? 1,
+          publish: a.publish ?? 1
+        });
         return { result: id, message: `Successfully created ticket note with ID: ${id}` };
       }],
       ['autotask_get_project_note', async (a) => {
@@ -1123,7 +1136,17 @@ export class AutotaskToolHandler {
         return { result: priorities.map(p => ({ id: p.value, name: p.label, isActive: p.isActive })), message: `Found ${priorities.length} ticket priorities` };
       }],
       ['autotask_get_field_info', async (a) => {
-        const fields = await this.picklistCache.getFields(a.entityType);
+        // Normalize common entity type aliases to correct Autotask REST API names
+        const entityAliases: Record<string, string> = {
+          'tasks': 'ProjectTasks',
+          'task': 'ProjectTasks',
+          'projecttask': 'ProjectTasks',
+          'ticketnotes': 'TicketNotes',
+          'projectnotes': 'ProjectNotes',
+          'companynotes': 'CompanyNotes',
+        };
+        const entityType = entityAliases[a.entityType.toLowerCase()] || a.entityType;
+        const fields = await this.picklistCache.getFields(entityType);
         if (a.fieldName) {
           const field = fields.find(f => f.name.toLowerCase() === a.fieldName.toLowerCase());
           return { result: field || null, message: field ? `Field info for ${a.entityType}.${a.fieldName}` : `Field '${a.fieldName}' not found on ${a.entityType}` };

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -34,7 +34,8 @@ import {
   AutotaskTicketCharge,
   AutotaskServiceCall,
   AutotaskServiceCallTicket,
-  AutotaskServiceCallTicketResource
+  AutotaskServiceCallTicketResource,
+  AutotaskPhase
 } from '../types/autotask';
 import { McpServerConfig } from '../types/mcp';
 import { Logger } from '../utils/logger';
@@ -1064,11 +1065,16 @@ export class AutotaskService {
 
   async createTask(task: Partial<AutotaskTask>): Promise<number> {
     const client = await this.ensureClient();
-    
+
     try {
       this.logger.debug('Creating task:', task);
-      const result = await client.tasks.create(task as any);
-      const taskId = (result.data as any)?.itemId ?? (result.data as any)?.id;
+      if (!task.projectID) {
+        throw new Error('projectID is required to create a task');
+      }
+      // Autotask REST API requires tasks to be created via POST /Projects/{projectID}/Tasks
+      const axiosInstance = (client as any).axios;
+      const response = await axiosInstance.post(`/Projects/${task.projectID}/Tasks`, task);
+      const taskId = response.data?.itemId ?? response.data?.id;
       this.logger.info(`Task created with ID: ${taskId}`);
       return taskId;
     } catch (error) {
@@ -1079,13 +1085,57 @@ export class AutotaskService {
 
   async updateTask(id: number, updates: Partial<AutotaskTask>): Promise<void> {
     const client = await this.ensureClient();
-    
+
     try {
       this.logger.debug(`Updating task ${id}:`, updates);
-      await client.tasks.update(id, updates as any);
+      if (!updates.projectID) {
+        throw new Error('projectID is required to update a task');
+      }
+      // Autotask REST API requires PATCH on collection endpoint: /Projects/{projectID}/Tasks
+      // with the task ID in the body, not in the URL
+      const axiosInstance = (client as any).axios;
+      await axiosInstance.patch(`/Projects/${updates.projectID}/Tasks`, { id, ...updates });
       this.logger.info(`Task ${id} updated successfully`);
     } catch (error) {
       this.logger.error(`Failed to update task ${id}:`, error);
+      throw error;
+    }
+  }
+
+  // Phase management
+  async createPhase(phase: Partial<AutotaskPhase>): Promise<number> {
+    const client = await this.ensureClient();
+
+    try {
+      this.logger.debug('Creating phase:', phase);
+      if (!phase.projectID) {
+        throw new Error('projectID is required to create a phase');
+      }
+      const axiosInstance = (client as any).axios;
+      const response = await axiosInstance.post(`/Projects/${phase.projectID}/Phases`, phase);
+      const phaseId = response.data?.itemId ?? response.data?.id;
+      this.logger.info(`Phase created with ID: ${phaseId}`);
+      return phaseId;
+    } catch (error) {
+      this.logger.error('Failed to create phase:', error);
+      throw error;
+    }
+  }
+
+  async searchPhases(projectID: number, options: AutotaskQueryOptions = {}): Promise<AutotaskPhase[]> {
+    const client = await this.ensureClient();
+
+    try {
+      this.logger.debug(`Searching phases for project ${projectID}:`, options);
+      const axiosInstance = (client as any).axios;
+      const response = await axiosInstance.get(`/Projects/${projectID}/Phases`, {
+        params: { pageSize: options.pageSize || 25 }
+      });
+      const phases = response.data?.items || response.data || [];
+      this.logger.info(`Retrieved ${phases.length} phases for project ${projectID}`);
+      return phases;
+    } catch (error) {
+      this.logger.error(`Failed to search phases for project ${projectID}:`, error);
       throw error;
     }
   }

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -174,6 +174,21 @@ export interface AutotaskTask {
   [key: string]: any;
 }
 
+export interface AutotaskPhase {
+  id?: number;
+  projectID?: number;
+  title?: string;
+  description?: string;
+  startDate?: string;
+  dueDate?: string;
+  estimatedHours?: number;
+  sortOrder?: number;
+  scheduled?: boolean;
+  createDate?: string;
+  lastActivityDateTime?: string;
+  [key: string]: any;
+}
+
 export interface AutotaskTicketNote {
   id?: number;
   ticketID?: number;


### PR DESCRIPTION
## Summary

Fixes multiple bugs discovered during real-world project setup (#46, #47):

### Bug fixes
- **Task creation 404**: Use `POST /Projects/{id}/Tasks` (nested endpoint) instead of `/Tasks`
- **Task updates**: Use PATCH on collection endpoint with `{id, ...fields}` per Autotask API pattern
- **Ticket note 500**: Default missing required fields (`title`, `noteType`, `publish`)
- **Field info wrong statuses**: Map `Tasks`/`Task` to `ProjectTasks` entity name

### New tools
- `autotask_create_phase` — create project phases
- `autotask_list_phases` — list phases for a project

Fixes #46 | Addresses #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)