### PR TITLE
fix(mapping): paginate company cache and stop caching direct-get fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+### Fixed
+
+- **`MappingService` company cache was silently truncated to 25 entries** — `refreshCompanyCache()` called `searchCompanies({})` assuming "no pageSize = fetch all pages", but the underlying `searchCompanies` defaults to `pageSize: 25, page: 1` and returns only the first page. The cache was then logged as `"COMPLETE dataset"`, which was incorrect.
+  - Effect: for any company whose ID wasn't on the first page (~everything past ID ~198 in a typical tenant), `getCompanyName()` fell through to a single-record `getCompany(id)` direct-lookup. When the Autotask REST direct-get returned a stale or renamed name (observed for at least one merged/renamed company in the wild), that wrong name was written into the cache and served to every downstream consumer — `autotask_search_tickets`, `autotask_search_projects`, notes, time entries, etc. — for a 30-minute cache window. Surface: the `company` field on enriched responses displayed the wrong tenant name, which looks like cross-tenant data leakage even though the underlying IDs and ownership were correct.
+  - Fix: `refreshCompanyCache()` now actually paginates — loops `searchCompanies({page, pageSize: 200})` until a short page is returned, building a fresh `Map` and atomic-swapping it into the cache only after full success (partial failures keep the prior cache rather than replacing it with a shorter one). Safety cap of 100 pages (20k companies) logs a warning rather than running forever.
+  - Hardening: `getCompanyName()` still falls back to single-record `getCompany(id)` for companies added between refresh windows, but the fallback result is no longer written to the cache. This prevents a stale/wrong direct-get from poisoning the cache and being served to every subsequent caller.
+  - Added `tests/mapping.test.ts` coverage: multi-page pagination, early-stop on short page, and fallback-does-not-poison-cache.
+
 # [2.18.0](https://github.com/wyre-technology/autotask-mcp/compare/v2.17.2...v2.18.0) (2026-04-08)
 
 

--- a/src/utils/mapping.service.ts
+++ b/src/utils/mapping.service.ts
@@ -106,23 +106,29 @@ export class MappingService {
   }
 
   /**
-   * Get company name by ID with fallback lookup
+   * Get company name by ID.
+   *
+   * Cache is the source of truth — populated by full paginated `list()` in
+   * `refreshCompanyCache`. A single-record `getCompany(id)` fallback exists
+   * for IDs added between refresh windows, but its result is NOT written to
+   * the cache: direct-get results have been observed to disagree with the
+   * paginated list for merged/renamed companies, and caching the bad value
+   * would then be served to every subsequent caller for 30 minutes.
    */
   public async getCompanyName(companyId: number): Promise<string | null> {
     try {
       await this.refreshCacheIfNeeded();
-      
-      // Try cache first
+
       const cachedName = this.cache.companies.get(companyId);
       if (cachedName) {
         return cachedName;
       }
-      
-      // Fallback: fetch the single company by ID rather than downloading the full list
-      this.logger.debug(`Company ${companyId} not in cache, doing direct lookup`);
+
+      this.logger.warn(
+        `Company ${companyId} missing from paginated cache (size=${this.cache.companies.size}); falling back to direct lookup. Result will NOT be cached.`
+      );
       const company = await this.autotaskService.getCompany(companyId);
       if (company?.companyName) {
-        this.cache.companies.set(companyId, company.companyName);
         return company.companyName;
       }
 
@@ -185,26 +191,47 @@ export class MappingService {
     this.refreshCompanyPromise = (async () => {
       try {
         this.logger.info('Refreshing company cache...');
-        
-        // Use pagination-by-default to get ALL companies for complete accuracy
-        const companies = await this.autotaskService.searchCompanies({
-          // No pageSize specified - gets ALL companies via pagination by default
-        });
 
-        this.cache.companies.clear();
-        
-        for (const company of companies) {
-          if (company.id && company.companyName) {
-            this.cache.companies.set(company.id, company.companyName);
+        // Walk every page of /Companies to build the cache. The previous
+        // implementation called searchCompanies({}) and assumed "no pageSize =
+        // fetch all", but searchCompanies actually defaults to pageSize 25 and
+        // returns only the first page — meaning the cache silently contained
+        // only ~25 companies. That caused getCompanyName() to fall through to
+        // direct-get for every other ID, and direct-get has been observed to
+        // return incorrect names for some companies (see CHANGELOG). Build
+        // the full cache in a fresh map and atomic-swap so a partial failure
+        // never replaces a good cache with a shorter one.
+        const pageSize = 200; // Autotask per-page cap per autotask.service.ts
+        const fresh = new Map<number, string>();
+        let page = 1;
+        const maxPages = 100; // hard safety stop: 20k companies
+
+        while (page <= maxPages) {
+          const batch = await this.autotaskService.searchCompanies({ page, pageSize });
+          for (const company of batch) {
+            if (company.id != null && company.companyName) {
+              fresh.set(company.id, company.companyName);
+            }
           }
+          if (batch.length < pageSize) break;
+          page += 1;
         }
 
+        if (page > maxPages) {
+          this.logger.warn(
+            `Company pagination hit safety cap (${maxPages} pages of ${pageSize}). Cache may be incomplete.`
+          );
+        }
+
+        this.cache.companies = fresh;
         this.cache.lastUpdated.companies = new Date();
-        this.logger.info(`Company cache refreshed with ${this.cache.companies.size} entries (COMPLETE dataset)`);
+        this.logger.info(
+          `Company cache refreshed with ${this.cache.companies.size} entries across ${page} page(s)`
+        );
 
       } catch (error) {
         this.logger.error('Failed to refresh company cache:', error);
-        // Don't throw error - allow fallback to direct lookup
+        // Don't throw — keep any previously valid cache rather than wiping it.
       } finally {
         this.refreshCompanyPromise = null;
       }

--- a/tests/mapping.test.ts
+++ b/tests/mapping.test.ts
@@ -117,6 +117,70 @@ describe('MappingService', () => {
     });
   });
 
+  describe('pagination', () => {
+    it('should paginate until all companies are fetched', async () => {
+      // Simulate a tenant with 250 companies — more than one page.
+      const page1 = Array.from({ length: 200 }, (_, i) => ({
+        id: i + 1,
+        companyName: `Company ${i + 1}`,
+      }));
+      const page2 = Array.from({ length: 50 }, (_, i) => ({
+        id: 200 + i + 1,
+        companyName: `Company ${200 + i + 1}`,
+      }));
+      mockService.searchCompanies
+        .mockResolvedValueOnce(page1 as any)
+        .mockResolvedValueOnce(page2 as any);
+
+      const instance = await MappingService.getInstance(mockService, mockLogger);
+
+      expect(mockService.searchCompanies).toHaveBeenCalledTimes(2);
+      expect(mockService.searchCompanies).toHaveBeenNthCalledWith(1, { page: 1, pageSize: 200 });
+      expect(mockService.searchCompanies).toHaveBeenNthCalledWith(2, { page: 2, pageSize: 200 });
+
+      // A company past the first page must be resolvable WITHOUT direct-lookup fallback.
+      const name = await instance.getCompanyName(207);
+      expect(name).toBe('Company 207');
+      expect((mockService as any).getCompany).toBeUndefined();
+    });
+
+    it('should stop paginating when a short page is returned', async () => {
+      mockService.searchCompanies.mockResolvedValueOnce([
+        { id: 1, companyName: 'Only Co' },
+      ] as any);
+
+      await MappingService.getInstance(mockService, mockLogger);
+
+      expect(mockService.searchCompanies).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT cache results of the direct-lookup fallback (prevents stale-name poisoning)', async () => {
+      // Tenant has one company; we ask for an ID not in that cache.
+      // Simulates the real-world bug: direct-get returns a stale/wrong name
+      // that previously got written to cache and served to every subsequent caller.
+      mockService.searchCompanies.mockResolvedValueOnce([
+        { id: 1, companyName: 'Acme Corp' },
+      ] as any);
+      (mockService as any).getCompany = jest
+        .fn()
+        .mockResolvedValue({ id: 207, companyName: 'Stale Name From Direct Get' });
+
+      const instance = await MappingService.getInstance(mockService, mockLogger);
+
+      const first = await instance.getCompanyName(207);
+      const second = await instance.getCompanyName(207);
+      expect(first).toBe('Stale Name From Direct Get');
+      expect(second).toBe('Stale Name From Direct Get');
+
+      // The fallback MUST be consulted on every call (not cached) so that a
+      // later paginated refresh can correct the name without stale overrides.
+      expect((mockService as any).getCompany).toHaveBeenCalledTimes(2);
+
+      const stats = instance.getCacheStats();
+      expect(stats.companies.count).toBe(1); // Only the one real company from pagination
+    });
+  });
+
   describe('error handling', () => {
     it('should handle searchCompanies failure gracefully', async () => {
       mockService.searchCompanies.mockRejectedValueOnce(new Error('API error'));


### PR DESCRIPTION
## Summary

- `MappingService.refreshCompanyCache` was silently truncating the company cache to 25 entries: it called `searchCompanies({})` expecting pagination, but the underlying method defaults to `pageSize: 25, page: 1` and returns only the first page. The init log still claimed `"COMPLETE dataset"`, which hid the problem.
- For any companyID past the first page, `getCompanyName()` fell through to a single-record `getCompany(id)` direct lookup. When the Autotask REST direct-get returned a stale/renamed name (observed in at least one tenant for a renamed/merged company), that wrong name was written to the cache and served to every downstream consumer — tickets, projects, notes, time entries — for a full 30-minute cache window.
- User-visible symptom: the `company` field on enriched tool responses displayed the **wrong tenant name** for any company past the first page. Reads like cross-tenant data leakage even though the underlying IDs and ownership are correct. In the reporter's tenant every ticket/project for companyID 207 came back enriched as "Family Music Centers" when the company is in fact "Lucent Glass".

## Fix

- `refreshCompanyCache` now actually paginates: loops `searchCompanies({ page, pageSize: 200 })` until a short page is returned, builds a fresh `Map`, and atomic-swaps it into the cache only after full success so a partial failure never replaces a good cache with a shorter one. 100-page / 20 000-company safety cap logs a warning instead of looping forever.
- `getCompanyName` keeps the `getCompany(id)` direct-lookup fallback for companies added between refresh windows, but **no longer writes the fallback result to the cache**. That closes the poisoning path: a bad direct-get can no longer be served to every subsequent caller.
- Comment that previously lied about pagination-by-default is replaced with an accurate one documenting the bug class and why we do it this way.

## Test plan

- [x] `npx jest tests/mapping.test.ts` — 15/15 pass, including 3 new tests:
  - `should paginate until all companies are fetched` (250-company fixture across two pages)
  - `should stop paginating when a short page is returned`
  - `should NOT cache results of the direct-lookup fallback (prevents stale-name poisoning)`
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke test after merge: in a tenant with >25 companies, call `autotask_search_tickets` filtered by a companyID past the first page and confirm the enriched `company` field matches `autotask_search_companies` for that same ID.

## Follow-ups (not in this PR)

- Re-ingest downstream consumers that stored the `company` field (e.g. Obsidian vault frontmatter, any reporting cache) after this ships.
- Consider adding a periodic audit log comparing direct-get result to paginated cache entry and warning on disagreement so future data drift is visible.