### PR TITLE
feat(tools): add autotask_raw_request escape hatch for any REST endpoint

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -2958,6 +2958,35 @@ export const TOOL_DEFINITIONS: McpTool[] = [
       },
       required: ['serviceCallTicketResourceId']
     }
+  },
+  {
+    name: 'autotask_raw_request',
+    description: 'Escape hatch for Autotask REST endpoints not yet wrapped by a typed tool. Use sparingly — typed tools are preferred for safety. The existing Content-Type, Accept, ApiIntegrationcode, UserName, Secret headers are added automatically. The path is resolved against the zone-resolved base URL (https://webservices<N>.autotask.net/ATServicesRest/v1.0). Pass queryParams as a flat object of string/number/boolean values; they will be URL-encoded and appended to the path.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        method: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PATCH', 'DELETE'],
+          description: 'HTTP method'
+        },
+        path: {
+          type: 'string',
+          description: 'Path under the Autotask REST v1.0 base (e.g. "/Companies/175" or "/Companies/query")'
+        },
+        body: {
+          type: 'object',
+          description: 'Optional JSON body for POST/PATCH requests',
+          additionalProperties: true
+        },
+        queryParams: {
+          type: 'object',
+          description: 'Optional flat key-value query parameters (e.g. { includeFields: "id,name" })',
+          additionalProperties: true
+        }
+      },
+      required: ['method', 'path']
+    }
   }
 ];
 

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -989,6 +989,12 @@ export class AutotaskToolHandler {
         const r = await s.searchContracts(a); return { result: r, message: `Found ${r.length} contracts` };
       }],
 
+      // Raw REST passthrough (escape hatch)
+      ['autotask_raw_request', async (a) => {
+        const r = await s.rawRequest(a.method, a.path, a.body, a.queryParams);
+        return { result: r, message: `Autotask ${a.method} ${a.path} completed` };
+      }],
+
       // Invoices
       ['autotask_search_invoices', async (a) => {
         const r = await s.searchInvoices(a); return { result: r, message: `Found ${r.length} invoices` };

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -124,6 +124,35 @@ export class AutotaskHttpClient {
   }
 
   /**
+   * Generic passthrough for any Autotask REST endpoint.
+   *
+   * Serializes `queryParams` onto the path as `?key=value&...` (URL-encoded)
+   * and reuses the same auth headers, timeout, error handling, and base URL
+   * resolution as every other method on this client.
+   *
+   * Use sparingly — typed helpers (get/query/create/update/delete) are
+   * preferred. This is the escape hatch for endpoints not yet wrapped.
+   */
+  async rawRequest<T = any>(
+    method: string,
+    path: string,
+    body?: any,
+    queryParams?: Record<string, string | number | boolean>
+  ): Promise<T> {
+    let finalPath = path;
+    if (queryParams && Object.keys(queryParams).length > 0) {
+      const qs = Object.entries(queryParams)
+        .filter(([, v]) => v !== undefined && v !== null)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+        .join('&');
+      if (qs) {
+        finalPath = `${path}${path.includes('?') ? '&' : '?'}${qs}`;
+      }
+    }
+    return this.request<T>(method, finalPath, body);
+  }
+
+  /**
    * GET /{Entity}/{id} — returns the entity, or null on 404.
    */
   async get<T>(entity: string, id: number): Promise<T | null> {

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -2224,6 +2224,26 @@ export class AutotaskService {
       throw error;
     }
   }
+
+  // =====================================================
+  // Raw REST passthrough (escape hatch)
+  // =====================================================
+
+  async rawRequest<T = any>(
+    method: string,
+    path: string,
+    body?: any,
+    queryParams?: Record<string, string | number | boolean>
+  ): Promise<T> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug(`Raw Autotask request ${method} ${path}`, { hasBody: body !== undefined, queryParams });
+      return await http.rawRequest<T>(method, path, body, queryParams);
+    } catch (error) {
+      this.logger.error(`Raw Autotask request ${method} ${path} failed:`, error);
+      throw error;
+    }
+  }
 }
 
 // resolveAutotaskApiUrl kept referenced to avoid unused-import warnings


### PR DESCRIPTION
## Summary

Adds a generic `autotask_raw_request` tool exposing any Autotask REST endpoint that isn't yet wrapped by a typed tool. High-leverage escape hatch for unblocking edge cases without waiting for a fresh release.

## Motivation

Working on a new-customer-onboarding automation against Autotask, I hit several Autotask fields and endpoints that aren't covered by the current typed tools (e.g. extended Companies fields, certain ContractServices subresources, ad-hoc picklist lookups). Rather than adding a new typed tool for every gap, this PR adds one generic passthrough so consumers can keep moving and you can prioritize typed tools at your pace.

## Design

- New public method `AutotaskHttpClient.rawRequest(method, path, body?, queryParams?)` (in `src/services/autotask-http.ts`):
  - Serializes `queryParams` via `encodeURIComponent` and appends to the path as `?k=v&...`
  - Delegates to the existing private `request<T>(method, path, body)` so all auth headers, 30-second timeout, and error normalization carry through unchanged
  - Did NOT change `request()` from private → public — keeps the diff minimal and preserves the existing internal contract
- New service-layer wrapper `AutotaskService.rawRequest(...)` that just delegates
- New MCP tool definition + handler dispatch
- Description on the tool warns: "Escape hatch... use sparingly — typed tools are preferred for safety"

## Tool surface

```
autotask_raw_request:
  method:       GET | POST | PATCH | DELETE   (required)
  path:         string                          (required, e.g. /Companies/175)
  body:         object                          (optional)
  queryParams:  object                          (optional, key-value)
```

## Testing

- `npm run build` clean (zero TS errors)
- Manual smoke: called `autotask_raw_request` with `method=GET path=/Version` against a sandbox tenant; identical response to the equivalent native `fetch` call
- Headers (`ApiIntegrationcode`, `UserName`, `Secret`, `Content-Type: application/json`, `Accept: application/json`) are added automatically

## Impact

- 4 files changed: `+84 / -0`
- No breaking changes (purely additive)
- No new runtime dependencies

Happy to iterate on naming, surface area, or response shape — open to feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)