### PR TITLE
feat(companies): expose webAddress / paymentTerm / taxRegion / invoiceTemplate / taxExempt fields on update_company

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -93,7 +93,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_update_company',
-    description: 'Update an existing company in Autotask',
+    description: 'Update an existing company in Autotask. Supports the core identity fields (companyName, phone, address1, city, state, postalCode, isActive) plus extended fields: webAddress, paymentTerm, taxRegionID, invoiceTemplateID, taxID, taxExempt, ownerResourceID, classification, companyType. Field names match the Autotask REST API exactly (camelCase, capital ID suffixes where applicable).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -128,6 +128,42 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         isActive: {
           type: 'boolean',
           description: 'Whether the company is active'
+        },
+        webAddress: {
+          type: 'string',
+          description: 'Company website URL (Autotask field name is webAddress, not website)'
+        },
+        paymentTerm: {
+          type: 'number',
+          description: 'Payment term picklist ID'
+        },
+        taxRegionID: {
+          type: 'number',
+          description: 'Tax region ID (capital ID suffix per Autotask convention)'
+        },
+        invoiceTemplateID: {
+          type: 'number',
+          description: 'Invoice template ID applied to this company'
+        },
+        taxID: {
+          type: 'string',
+          description: 'Tax registration / VAT identifier string'
+        },
+        taxExempt: {
+          type: 'boolean',
+          description: 'Whether the company is tax-exempt'
+        },
+        ownerResourceID: {
+          type: 'number',
+          description: 'Resource ID of the account owner'
+        },
+        classification: {
+          type: 'number',
+          description: 'Company classification picklist ID'
+        },
+        companyType: {
+          type: 'number',
+          description: 'Company type picklist ID (e.g. Customer, Prospect, Vendor)'
         }
       },
       required: ['id']


### PR DESCRIPTION
## Summary

Expands the `autotask_update_company` tool's input schema with 9 additional Autotask Companies fields. Pure schema-additive change — no service or HTTP layer changes needed because `updateCompany` already pass-through-spreads any provided fields via `http.update('Companies', id, updates as Record<string, any>)`.

## Fields added

| Field | Type | Why |
|---|---|---|
| `webAddress` | string | Customer website URL (Autotask field name is `webAddress`, not `website`) |
| `paymentTerm` | number | Payment terms picklist (e.g. NET 30) |
| `taxRegionID` | number | Tax region picklist |
| `invoiceTemplateID` | number | Invoice template (e.g. NET 30 vs Due on Receipt) |
| `taxID` | string | Customer tax ID / FEIN |
| `taxExempt` | boolean | Tax-exempt flag |
| `ownerResourceID` | number | Account owner |
| `classification` | number | Company classification picklist |
| `companyType` | number | Company type picklist |

## Motivation

Building automation around customer onboarding — most of the "Invoice Preferences" and "Customer Setup" steps in our standard NCO checklist (NET-30 default, tax region, tax exemption, customer website, classification tier) couldn't be automated through the existing tool because the fields weren't in the schema. The service layer already accepted them; just the schema gate was tight.

## Testing

- `npm run build` clean
- Manual: PATCH against sandbox tenant Companies record with each new field individually returned `{}` (Autotask's standard PATCH response) and the field updated correctly

## Impact

- 1 file changed: `+37 / -1`
- No breaking changes (purely additive properties on the input schema)
- Existing `id, address1, city, companyName, isActive, phone, postalCode, state` fields remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)