### PR TITLE
feat(contacts): add autotask_update_contact tool

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -235,6 +235,76 @@ export const TOOL_DEFINITIONS: McpTool[] = [
       required: ['companyID', 'firstName', 'lastName']
     }
   },
+  {
+    name: 'autotask_update_contact',
+    description: 'Update an existing contact in Autotask. Pass only the fields you want to change; all non-id fields are optional. Field names match the Autotask REST API exactly.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Contact ID to update'
+        },
+        firstName: {
+          type: 'string',
+          description: 'Contact first name'
+        },
+        lastName: {
+          type: 'string',
+          description: 'Contact last name'
+        },
+        emailAddress: {
+          type: 'string',
+          description: 'Primary email address'
+        },
+        phone: {
+          type: 'string',
+          description: 'Primary phone number'
+        },
+        title: {
+          type: 'string',
+          description: 'Job title'
+        },
+        isActive: {
+          type: 'boolean',
+          description: 'Whether the contact is active'
+        },
+        mobilePhone: {
+          type: 'string',
+          description: 'Mobile phone number'
+        },
+        addressLine: {
+          type: 'string',
+          description: 'Address line (primary)'
+        },
+        addressLine1: {
+          type: 'string',
+          description: 'Address line 1 (secondary)'
+        },
+        city: {
+          type: 'string',
+          description: 'City'
+        },
+        state: {
+          type: 'string',
+          description: 'State/province'
+        },
+        zipCode: {
+          type: 'string',
+          description: 'Postal/ZIP code'
+        },
+        countryID: {
+          type: 'number',
+          description: 'Country ID (Autotask Countries entity)'
+        },
+        primaryContact: {
+          type: 'boolean',
+          description: 'Whether this contact is the primary contact for their company'
+        }
+      },
+      required: ['id']
+    }
+  },
 
   // Ticket tools
   {

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -787,6 +787,9 @@ export class AutotaskToolHandler {
       ['autotask_create_contact', async (a) => {
         const id = await s.createContact(a); return { result: id, message: `Successfully created contact with ID: ${id}` };
       }],
+      ['autotask_update_contact', async (a) => {
+        await s.updateContact(a.id, a); return { result: undefined, message: `Successfully updated contact ID: ${a.id}` };
+      }],
 
       // Tickets
       ['autotask_search_tickets', async (a) => {


### PR DESCRIPTION
## Summary

Exposes a missing `autotask_update_contact` tool. The service-layer `updateContact(id, updates)` method already exists in `src/services/autotask.service.ts` (around line 246) — it just was never wired up as an MCP tool.

## Surface

```
autotask_update_contact:
  id:            number  (required)
  firstName:     string
  lastName:      string
  emailAddress:  string
  phone:         string
  title:         string
  isActive:      boolean
  mobilePhone:   string
  addressLine:   string
  addressLine1:  string
  city:          string
  state:         string
  zipCode:       string
  countryID:     number
  primaryContact: boolean
```

Mirrors the `autotask_update_company` pattern — service method passes any fields through, schema is permissive but documents the common ones.

## Motivation

Without this tool, the only ways to mutate a contact are (a) deleting and re-creating it, or (b) using the new `autotask_raw_request` escape hatch in the sister PR. Both feel wrong when the underlying service method already exists.

## Testing

- `npm run build` clean
- Manual: PATCH against a sandbox contact with `{firstName, emailAddress, phone}` returned the expected updated record

## Impact

- 2 files changed: `+73 / -0`
- No breaking changes
- No service or HTTP layer changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)