### PR TITLE
feat(contracts): add CRUD tools for Contracts and ContractServices

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -2958,6 +2958,128 @@ export const TOOL_DEFINITIONS: McpTool[] = [
       },
       required: ['serviceCallTicketResourceId']
     }
+  },
+
+  // Contracts (write) and ContractServices CRUD
+  {
+    name: 'autotask_create_contract',
+    description: 'Create a new Contract in Autotask. Field names match the Autotask REST API exactly. status: 1=In Effect, 0=Inactive. Dates are ISO format (YYYY-MM-DD).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        companyID: { type: 'number', description: 'Company ID the contract is associated with' },
+        contractName: { type: 'string', description: 'Contract name' },
+        contractType: { type: 'number', description: 'Contract type picklist ID' },
+        contractCategory: { type: 'number', description: 'Contract category picklist ID' },
+        startDate: { type: 'string', description: 'Contract start date (ISO YYYY-MM-DD)' },
+        endDate: { type: 'string', description: 'Contract end date (ISO YYYY-MM-DD)' },
+        contactID: { type: 'number', description: 'Primary contact ID for the contract' },
+        contractNumber: { type: 'string', description: 'External-facing contract number' },
+        contractPeriodType: { type: 'number', description: 'Period type picklist ID' },
+        description: { type: 'string', description: 'Contract description / notes' },
+        estimatedCost: { type: 'number', description: 'Estimated cost' },
+        estimatedHours: { type: 'number', description: 'Estimated hours' },
+        estimatedRevenue: { type: 'number', description: 'Estimated revenue' },
+        setupFee: { type: 'number', description: 'Setup fee amount' },
+        overageBillingRate: { type: 'number', description: 'Overage billing rate' },
+        serviceLevelAgreementID: { type: 'number', description: 'SLA ID' },
+        purchaseOrderNumber: { type: 'string', description: 'Customer purchase order number' },
+        opportunityID: { type: 'number', description: 'Originating opportunity ID' },
+        billingPreference: { type: 'number', description: 'Billing preference picklist ID' },
+        billToCompanyID: { type: 'number', description: 'Bill-to company ID' },
+        billToCompanyContactID: { type: 'number', description: 'Bill-to contact ID' },
+        exclusionContractID: { type: 'number', description: 'Exclusion contract ID' },
+        isDefaultContract: { type: 'boolean', description: 'Whether this is the default contract for the company' },
+        internalCurrencySetupFee: { type: 'number', description: 'Setup fee in internal currency' },
+        internalCurrencyOverageBillingRate: { type: 'number', description: 'Overage rate in internal currency' },
+        organizationalLevelAssociationID: { type: 'number', description: 'Org level association ID' },
+        contractExclusionSetID: { type: 'number', description: 'Contract exclusion set ID' },
+        renewedContractID: { type: 'number', description: 'ID of the contract this renewed' },
+        setupFeeBillingCodeID: { type: 'number', description: 'Billing code ID for the setup fee' },
+        status: { type: 'number', description: 'Contract status (1=In Effect, 0=Inactive)' },
+        timeReportingRequiresStartAndStopTimes: { type: 'number', description: 'Whether time entries require start/stop times' }
+      },
+      required: ['companyID', 'contractName', 'contractType', 'contractCategory', 'startDate', 'endDate']
+    }
+  },
+  {
+    name: 'autotask_update_contract',
+    description: 'Update an existing Contract in Autotask (PATCH). Pass only fields you want to change; everything except id is optional. status: 1=In Effect, 0=Inactive.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', description: 'Contract ID to update' },
+        companyID: { type: 'number', description: 'Company ID' },
+        contractName: { type: 'string', description: 'Contract name' },
+        contractType: { type: 'number', description: 'Contract type picklist ID' },
+        contractCategory: { type: 'number', description: 'Contract category picklist ID' },
+        startDate: { type: 'string', description: 'Contract start date (ISO YYYY-MM-DD)' },
+        endDate: { type: 'string', description: 'Contract end date (ISO YYYY-MM-DD)' },
+        contactID: { type: 'number', description: 'Primary contact ID' },
+        contractNumber: { type: 'string', description: 'External-facing contract number' },
+        contractPeriodType: { type: 'number', description: 'Period type picklist ID' },
+        description: { type: 'string', description: 'Contract description / notes' },
+        estimatedCost: { type: 'number', description: 'Estimated cost' },
+        estimatedHours: { type: 'number', description: 'Estimated hours' },
+        estimatedRevenue: { type: 'number', description: 'Estimated revenue' },
+        setupFee: { type: 'number', description: 'Setup fee amount' },
+        overageBillingRate: { type: 'number', description: 'Overage billing rate' },
+        serviceLevelAgreementID: { type: 'number', description: 'SLA ID' },
+        purchaseOrderNumber: { type: 'string', description: 'Customer purchase order number' },
+        opportunityID: { type: 'number', description: 'Originating opportunity ID' },
+        billingPreference: { type: 'number', description: 'Billing preference picklist ID' },
+        billToCompanyID: { type: 'number', description: 'Bill-to company ID' },
+        billToCompanyContactID: { type: 'number', description: 'Bill-to contact ID' },
+        exclusionContractID: { type: 'number', description: 'Exclusion contract ID' },
+        isDefaultContract: { type: 'boolean', description: 'Whether this is the default contract for the company' },
+        internalCurrencySetupFee: { type: 'number', description: 'Setup fee in internal currency' },
+        internalCurrencyOverageBillingRate: { type: 'number', description: 'Overage rate in internal currency' },
+        organizationalLevelAssociationID: { type: 'number', description: 'Org level association ID' },
+        contractExclusionSetID: { type: 'number', description: 'Contract exclusion set ID' },
+        renewedContractID: { type: 'number', description: 'ID of the contract this renewed' },
+        setupFeeBillingCodeID: { type: 'number', description: 'Billing code ID for the setup fee' },
+        status: { type: 'number', description: 'Contract status (1=In Effect, 0=Inactive)' },
+        timeReportingRequiresStartAndStopTimes: { type: 'number', description: 'Whether time entries require start/stop times' }
+      },
+      required: ['id']
+    }
+  },
+  {
+    name: 'autotask_create_contract_service',
+    description: 'Add a ContractService (service line item) to an existing Contract.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        contractID: { type: 'number', description: 'Parent Contract ID' },
+        serviceID: { type: 'number', description: 'Service catalog ID being attached to the contract' },
+        unitPrice: { type: 'number', description: 'Unit price for the service line' },
+        unitCost: { type: 'number', description: 'Unit cost for the service line' },
+        quoteItemID: { type: 'number', description: 'Originating quote item ID, if any' },
+        internalCurrencyUnitPrice: { type: 'number', description: 'Unit price in internal currency' },
+        adjustedPrice: { type: 'number', description: 'Adjusted price' },
+        invoiceDescription: { type: 'string', description: 'Override invoice description for this line' }
+      },
+      required: ['contractID', 'serviceID', 'unitPrice']
+    }
+  },
+  {
+    name: 'autotask_update_contract_service',
+    description: 'Update an existing ContractService line on a Contract. Pass only fields you want to change.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', description: 'ContractService record ID to update' },
+        contractID: { type: 'number', description: 'Parent Contract ID' },
+        serviceID: { type: 'number', description: 'Service catalog ID' },
+        unitPrice: { type: 'number', description: 'Unit price for the service line' },
+        unitCost: { type: 'number', description: 'Unit cost for the service line' },
+        quoteItemID: { type: 'number', description: 'Originating quote item ID' },
+        internalCurrencyUnitPrice: { type: 'number', description: 'Unit price in internal currency' },
+        adjustedPrice: { type: 'number', description: 'Adjusted price' },
+        invoiceDescription: { type: 'string', description: 'Override invoice description for this line' }
+      },
+      required: ['id', 'contractID']
+    }
   }
 ];
 

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -988,6 +988,20 @@ export class AutotaskToolHandler {
       ['autotask_search_contracts', async (a) => {
         const r = await s.searchContracts(a); return { result: r, message: `Found ${r.length} contracts` };
       }],
+      ['autotask_create_contract', async (a) => {
+        const id = await s.createContract(a); return { result: id, message: `Successfully created contract with ID: ${id}` };
+      }],
+      ['autotask_update_contract', async (a) => {
+        const { id, ...rest } = a;
+        await s.updateContract(id, rest); return { result: undefined, message: `Successfully updated contract ID: ${id}` };
+      }],
+      ['autotask_create_contract_service', async (a) => {
+        const id = await s.createContractService(a); return { result: id, message: `Successfully created contract service with ID: ${id}` };
+      }],
+      ['autotask_update_contract_service', async (a) => {
+        const { id, ...rest } = a;
+        await s.updateContractService(id, rest); return { result: undefined, message: `Successfully updated contract service ID: ${id}` };
+      }],
 
       // Invoices
       ['autotask_search_invoices', async (a) => {

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -839,6 +839,60 @@ export class AutotaskService {
   }
 
   // =====================================================
+  // Contracts (write) and ContractServices CRUD
+  // =====================================================
+
+  async createContract(contract: Partial<AutotaskContract>): Promise<number> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug('Creating contract:', contract);
+      const id = await http.create('Contracts', contract);
+      this.logger.info(`Contract created with ID: ${id}`);
+      return id;
+    } catch (error) {
+      this.logger.error('Failed to create contract:', error);
+      throw error;
+    }
+  }
+
+  async updateContract(id: number, updates: Partial<AutotaskContract>): Promise<void> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug(`Updating contract ${id}:`, updates);
+      await http.update('Contracts', id, updates as Record<string, any>);
+      this.logger.info(`Contract ${id} updated successfully`);
+    } catch (error) {
+      this.logger.error(`Failed to update contract ${id}:`, error);
+      throw error;
+    }
+  }
+
+  async createContractService(cs: Record<string, any>): Promise<number> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug('Creating contract service:', cs);
+      const id = await http.create('ContractServices', cs);
+      this.logger.info(`ContractService created with ID: ${id}`);
+      return id;
+    } catch (error) {
+      this.logger.error('Failed to create contract service:', error);
+      throw error;
+    }
+  }
+
+  async updateContractService(id: number, updates: Record<string, any>): Promise<void> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug(`Updating contract service ${id}:`, updates);
+      await http.update('ContractServices', id, updates);
+      this.logger.info(`ContractService ${id} updated successfully`);
+    } catch (error) {
+      this.logger.error(`Failed to update contract service ${id}:`, error);
+      throw error;
+    }
+  }
+
+  // =====================================================
   // Invoices
   // =====================================================
 


### PR DESCRIPTION
## Summary

Adds 4 new MCP tools for Contracts write operations:

- `autotask_create_contract`
- `autotask_update_contract`
- `autotask_create_contract_service`
- `autotask_update_contract_service`

The Contracts entity was previously read-only via this MCP (only `autotask_search_contracts` and `autotask_get_contract` existed). This PR adds full CRUD on Contracts and basic CRUD on ContractServices (the line-item subresource).

## Motivation

Contracts CRUD is a foundational gap. Several common workflows that rely on this MCP need to:

1. Create new contracts when a quote is accepted (e.g. T&M Exclusion, Managed IT Services, Software & Service Subscriptions contracts as separate records on the same customer)
2. Link contracts to each other (e.g. setting `exclusionContractID` on a Managed IT Services contract to point to its T&M Exclusion contract — this requires `autotask_update_contract`)
3. Add ContractServices line items to a Software & Service Subscriptions contract for each subscribed product

Without these tools, the only path was the new `autotask_raw_request` escape hatch (sister PR), which works but loses type-safety and discoverability.

## Surface

`autotask_create_contract` — required: `companyID, contractName, contractType, contractCategory, startDate, endDate`. Optional fields cover the full Contract record including: `contactID, contractNumber, contractPeriodType, description, estimatedCost, estimatedHours, estimatedRevenue, setupFee, overageBillingRate, serviceLevelAgreementID, purchaseOrderNumber, opportunityID, billingPreference, billToCompanyID, billToCompanyContactID, exclusionContractID, isDefaultContract, internalCurrencySetupFee, internalCurrencyOverageBillingRate, organizationalLevelAssociationID, contractExclusionSetID, renewedContractID, setupFeeBillingCodeID, status, timeReportingRequiresStartAndStopTimes`.

`autotask_update_contract` — required: `id`. All other Contract fields optional (PATCH semantics).

`autotask_create_contract_service` — required: `contractID, serviceID, unitPrice`. Optional: `unitCost, quoteItemID, internalCurrencyUnitPrice, adjustedPrice, invoiceDescription`.

`autotask_update_contract_service` — required: `id, contractID`. All other fields optional.

## Implementation notes

- Uses the existing generic `http.create('Contracts', body)` and `http.update('Contracts', id, body)` from `AutotaskHttpClient` — same pattern as existing `createCompany` / `updateCompany`. No new HTTP layer code.
- `AutotaskContract` interface in `src/types/autotask.ts` already has `[key: string]: any` index signature, so all extra Contract fields flow through without any type extensions.
- ContractService payloads typed as `Record<string, any>` since there's no existing `AutotaskContractService` type. Happy to add one if you'd prefer.
- Tool definitions placed at the end of `TOOL_DEFINITIONS` in a "Contracts (write) and ContractServices CRUD" section.
- Handler entries placed adjacent to the existing read-only `autotask_search_contracts` handler.
- Status field documented inline: `1 = In Effect, 0 = Inactive`.

## Testing

- `npm run build` clean (zero TS errors)
- Manual against a sandbox tenant: created a test Managed IT Services contract via `autotask_create_contract`, linked a T&M Exclusion via `autotask_update_contract` setting `exclusionContractID`, and added a ContractService line item via `autotask_create_contract_service` — all returned expected ids and updated records

## Impact

- 3 files changed: `+190 / -0`
- No breaking changes
- No new runtime dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)