### PR TITLE
feat(tickets): add contactID filter to autotask_search_tickets

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -421,6 +421,10 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'number',
           description: 'Filter by company ID'
         },
+        contactID: {
+          type: 'number',
+          description: 'Filter by primary contact ID — returns only tickets where contactID matches'
+        },
         status: {
           type: 'number',
           description: 'Filter by ticket status ID (omit for all open tickets)'

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -295,8 +295,14 @@ export class AutotaskService {
         filters.push({ op: 'eq', field: 'assignedResourceID', value: options.assignedResourceID });
       }
 
-      if (options.companyId !== undefined) {
-        filters.push({ op: 'eq', field: 'companyID', value: options.companyId });
+      const companyId = options.companyID ?? options.companyId;
+      if (companyId !== undefined) {
+        filters.push({ op: 'eq', field: 'companyID', value: companyId });
+      }
+
+      const contactId = options.contactID ?? options.contactId;
+      if (contactId !== undefined) {
+        filters.push({ op: 'eq', field: 'contactID', value: contactId });
       }
 
       if (options.createdAfter) {

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -553,7 +553,9 @@ export interface AutotaskQueryOptionsExtended extends AutotaskQueryOptions {
   expand?: string[];
   submitterId?: number;
   companyId?: number;
+  companyID?: number;
   contactId?: number;
+  contactID?: number;
   opportunityId?: number;
   searchTerm?: string;
   status?: number;


### PR DESCRIPTION
Closes #65.

## Summary

Adds `contactID` as a supported filter on `autotask_search_tickets` so callers can find tickets by primary contact directly, instead of fetching all tickets for a company and inspecting each record.

## Bonus fix: companyID casing bug

While wiring up `contactID` I found that the existing `companyID` filter had been silently broken — the JSON schema exposed `companyID` (Autotask's REST convention) but the service code at `searchTickets` read `options.companyId` (lowercase d), so the LLM-supplied filter was being silently dropped.

This PR fixes both filters by accepting either casing:
```ts
const companyId = options.companyID ?? options.companyId;
const contactId = options.contactID ?? options.contactId;
```

So callers passing either form continue to work, and the tool now actually applies the filter the schema advertises.

## Files

- `src/handlers/tool.definitions.ts` — adds `contactID` to the search_tickets schema next to `companyID`.
- `src/services/autotask.service.ts` — adds the contactID Autotask filter; fixes the companyID casing.
- `src/types/autotask.ts` — adds `companyID?` and `contactID?` aliases on `AutotaskQueryOptionsExtended`.

## Testing

- Build clean, all 78 tests pass.
- Behavior verified by reading Autotask field info: `contactID isQueryable: true` on Tickets entity (per the issue).