### PR TITLE
Fix: autotask_test_connection sets isError=true on connection failure

### DIFF
--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -758,7 +758,10 @@ export class AutotaskToolHandler {
       // Connection
       ['autotask_test_connection', async () => {
         const ok = await s.testConnection();
-        return { result: { success: ok }, message: ok ? 'Successfully connected to Autotask API' : 'Connection failed' };
+        if (!ok) {
+          throw new Error('Connection to Autotask API failed. Verify AUTOTASK_USERNAME, AUTOTASK_SECRET, and AUTOTASK_INTEGRATION_CODE are configured correctly and that the API user has at least read access to Companies.');
+        }
+        return { result: { success: true }, message: 'Successfully connected to Autotask API' };
       }],
 
       // Companies


### PR DESCRIPTION
Fixes #81.

## Problem

`autotask_test_connection` returned a successful tool result with the failure buried in the payload:

```json
{
  "content": [{"type": "text", "text": "{\"message\":\"Connection failed\",\"data\":{\"success\":false}}"}],
  "isError": false
}
```

LLM clients that gate on `isError` saw the call as successful — even though the connection actually failed. Inconsistent with every other autotask tool, which throws on failure and gets `isError: true` via the `callTool` wrapper's catch.

## Fix

The dispatch handler now throws when `testConnection()` returns false. The existing catch block in `callTool` (line 1463) maps the thrown error to:

```json
{
  "content": [{"type": "text", "text": "{\"error\":\"Connection to Autotask API failed...\",\"tool\":\"autotask_test_connection\"}"}],
  "isError": true
}
```

The error message includes the env var names a user needs to configure, so the failure mode is self-explanatory.

## Verification

```bash
$ npm run build
$ AUTOTASK_USERNAME= AUTOTASK_SECRET= AUTOTASK_INTEGRATION_CODE= \
  (initialize + tools/call autotask_test_connection) | node dist/entry.js
{..."isError":true,...}  # was: {..."isError":false,...}
```

Also passes the eval suite added in #80.