### PR TITLE
Opt in to org PR spam triage (dry-run)

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,17 @@
+name: PR triage
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  spam:
+    uses: wyre-technology/.github/.github/workflows/pr-spam-triage.yml@main
+    with:
+      # Start in dry-run: label spam-suspected PRs but don't close.
+      # Flip to false after a verification window (~1 week) of zero false positives.
+      dry-run: true


### PR DESCRIPTION
## Summary
- Wires this repo to the reusable spam-triage workflow being added in [wyre-technology/.github#3](https://github.com/wyre-technology/.github/pull/3).
- Starts in **dry-run mode**: spam-pattern PRs get labeled `spam-suspected` but are **not closed** automatically. Lets us verify zero false positives before flipping the switch.

## Why this repo first
We've been getting MseeP.ai badge-spam PRs here (e.g. recently-closed #83). Good place to validate the patterns since we know we'll see real traffic.

## Test plan
- [ ] Wait for [`.github` PR](https://github.com/wyre-technology/.github/pull/3) to land
- [ ] Watch for the next inbound badge-spam PR — it should get the `spam-suspected` label and a triage comment, but stay open
- [ ] Confirm no false positives on legitimate PRs over ~1 week
- [ ] Follow-up PR to flip `dry-run: true` → `dry-run: false`