### PR TITLE
feat(registry): publish to MCP Registry on release (canary)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
     permissions:
       contents: write
       issues: write
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
+      released: ${{ steps.release-version.outputs.released }}
 
     steps:
       - name: Checkout
@@ -115,21 +118,27 @@ jobs:
   docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    needs: [test]
+    # Sequence after release so the image tag reflects the bumped version
+    # rather than the pre-release version baked into package.json on the
+    # triggering commit. The MCP Registry verifies tag-pinned images, so
+    # tag/version drift breaks publishing.
+    needs: [release]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout
+      - name: Checkout (post-release commit)
         uses: actions/checkout@v4
         with:
+          # main has been advanced by semantic-release's chore(release) commit
+          ref: main
           fetch-depth: 0
-      
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -219,3 +228,52 @@ jobs:
             --resource-group mcp-gateway-prod \
             --image "$IMAGE" \
             --set-env-vars "IMAGE_VERSION=sha-${SHORT_SHA}-${GITHUB_RUN_ID}"
+
+  mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: [release, docker]
+    # Only publish to the registry on actual semantic-release versions
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      id-token: write   # Required for GitHub OIDC auth to the MCP Registry
+      contents: read
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout (post-release commit)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Stamp version into server.json
+        # server.json is committed with version "0.0.0" placeholders; replace
+        # them with the just-released version so the OCI identifier points at
+        # the image tag the docker job just pushed.
+        run: |
+          jq --arg v "$VERSION" \
+            '.version = $v
+             | .packages[0].identifier = "ghcr.io/wyre-technology/autotask-mcp:v" + $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+
+      - name: Verify registry listing
+        run: |
+          sleep 5
+          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/autotask-mcp" \
+            | jq '.servers[] | {name, version}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,7 @@ LABEL org.opencontainers.image.source="https://github.com/wyre-technology/autota
 LABEL org.opencontainers.image.documentation="https://github.com/wyre-technology/autotask-mcp/blob/main/README.md"
 LABEL org.opencontainers.image.url="https://github.com/wyre-technology/autotask-mcp/pkgs/container/autotask-mcp"
 LABEL org.opencontainers.image.vendor="Wyre Technology"
-LABEL org.opencontainers.image.licenses="Apache-2.0" 
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# MCP Registry ownership annotation (must match `name` in server.json)
+LABEL io.modelcontextprotocol.server.name="io.github.wyre-technology/autotask-mcp"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.wyre-technology/autotask-mcp",
+  "title": "Autotask",
+  "description": "MCP server for Kaseya Autotask PSA — companies, tickets, projects, time entries, and more.",
+  "repository": {
+    "url": "https://github.com/wyre-technology/autotask-mcp",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "websiteUrl": "https://github.com/wyre-technology/autotask-mcp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/wyre-technology/autotask-mcp:0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "AUTOTASK_USERNAME",
+          "description": "Autotask API user resource email (e.g. apiuser@example.com)",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "AUTOTASK_SECRET",
+          "description": "Autotask API user secret",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "AUTOTASK_INTEGRATION_CODE",
+          "description": "Autotask API integration code (tracking identifier)",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "AUTOTASK_API_URL",
+          "description": "Autotask API zone URL — auto-detected per tenant if omitted",
+          "isRequired": false,
+          "format": "string"
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Transport mode for the server. Set to 'stdio' for local CLI use; the image defaults to 'http' for gateway hosting.",
+          "isRequired": false,
+          "default": "stdio",
+          "format": "string"
+        },
+        {
+          "name": "AUTH_MODE",
+          "description": "Credential source: 'env' reads vars locally, 'gateway' expects header injection from the WYRE MCP Gateway.",
+          "isRequired": false,
+          "default": "env",
+          "format": "string"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Log verbosity: debug, info, warn, error",
+          "isRequired": false,
+          "default": "info",
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Wires `autotask-mcp` into the official MCP Registry (`registry.modelcontextprotocol.io`) using **OCI / GHCR** as the package source — no npm involved.

This is the **canary** for the broader 31-server fleet rollout under the `io.github.wyre-technology/*` namespace. Once this lands and a release fires, the same pattern fans out to the rest of the `*-mcp` repos.

## What changes

1. **`Dockerfile`** — adds `LABEL io.modelcontextprotocol.server.name="io.github.wyre-technology/autotask-mcp"`. The registry verifies OCI ownership by inspecting this annotation on the published image.

2. **`server.json`** (new) — describes the server (description, repository, transport, credential env vars) for the registry. Validated locally with `mcp-publisher validate` ✅. Version + image identifier are committed as `0.0.0` placeholders and stamped at release time by the workflow.

3. **`.github/workflows/release.yml`**:
   - **`docker` is now sequenced after `release`.** Today these run in parallel from the same commit, so the GHCR image tag is always one version behind the just-released GitHub release (semantic-release bumps `package.json` and pushes a `chore(release)` commit, but docker has already read the pre-bump version). Registry publishing requires `tag == version`, so this fixes that drift as a side benefit.
   - New **`mcp-registry`** job runs only on actual semantic-release versions (`needs.release.outputs.released == 'true'`). Uses **GitHub OIDC** (no secrets) to authenticate to the registry, stamps the version into `server.json`, and publishes.

## Auth model
- **MCP Registry**: GitHub OIDC via `id-token: write` — zero secrets.
- **GHCR**: existing `GITHUB_TOKEN` (unchanged).
- **No npm publishing.** `.releaserc.json` already has `npmPublish: false` — that stays.

## Test plan
- [ ] Confirm CI green on this PR (test matrix only — release/docker/mcp-registry don't run on PRs)
- [ ] Merge to main
- [ ] semantic-release fires → bumps version → `docker` builds and pushes `ghcr.io/wyre-technology/autotask-mcp:v<NEW>` and `:latest`
- [ ] `mcp-registry` job stamps version into `server.json`, validates, OIDC-auths, publishes
- [ ] Verify with: `curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/autotask-mcp"`
- [ ] If clean, port the same diff to the other 30 `*-mcp` repos (subagent fan-out)

## Risk notes
- The `docker` → `release` sequencing is a structural change to a working pipeline. Net effect on non-release pushes to main: docker now waits ~2 min for `release` to finish before building. On release commits: tag/version drift is fixed.
- `deploy` and `security` jobs (which `needs: [docker]`) are unaffected — they continue running off the same docker job, just sequenced later.