### PR TITLE
fix(release): docker tag uses release output, not package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,11 +129,9 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout (post-release commit)
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          # main has been advanced by semantic-release's chore(release) commit
-          ref: main
           fetch-depth: 0
 
       - name: Set up Docker Buildx
@@ -146,9 +144,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get version from package.json
+      - name: Resolve release version
         id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        # Source of truth is the release job's computed version (semantic-release's
+        # in-memory bump). Reading package.json here would be wrong because
+        # @semantic-release/git's push back to main is silently dropped by
+        # branch protection — package.json on main has been stuck at 2.18.0
+        # for several releases. We use the release output so docker tags match
+        # the GitHub release/git tag.
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "ERROR: needs.release.outputs.version is empty" >&2
+            exit 1
+          fi
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## Summary
Unblocks the registry publish job that's been failing since the canary merge with `OCI image 'ghcr.io/wyre-technology/autotask-mcp:v2.24.0' does not exist`. The image actually pushed to GHCR was tagged `v2.18.0` because the docker job reads package.json, which has been stuck at 2.18.0 for ~6 releases.

## Root cause
`@semantic-release/git`'s push of the `chore(release): X.Y.Z` commit to main is silently dropped by branch protection (which requires code-owner reviews). semantic-release exits 0, the GitHub release + git tag are created, but package.json never lands on main. Each subsequent release further entrenches the drift:

| Tag | package.json on tag commit |
|---|---|
| v2.18.0 | 2.18.0 |
| v2.19.0 | 2.18.0 ← drift starts |
| v2.20.0 | 2.18.0 |
| ... | 2.18.0 |
| v2.23.0 | 2.18.0 |
| v2.24.0 | 2.18.0 |

Until the new MCP-registry job, nothing checked tag/image alignment, so it was invisible.

## What this PR does
Sources the docker tag from `needs.release.outputs.version` (semantic-release's in-memory bump, computed before any push) instead of reading the on-disk `package.json`. The release output is already correct; we just weren't using it for docker.

## What this PR does NOT do
The underlying `@semantic-release/git` push problem still exists. Two reasonable fixes for a follow-up:
- **Drop `@semantic-release/git` from `.releaserc.json`**. CHANGELOG.md and package.json bumps stop landing on main, but git tags + GitHub releases are the source of truth anyway. Cleanest.
- **Grant the workflow token branch-protection bypass** so the push works. Keeps the changelog flowing on main, but expands the blast radius if the workflow is ever compromised.

## Test plan
- [ ] Merge this PR (admin-merge ok — small, contained, fixes a known bug)
- [ ] Trigger a release run (a fresh `feat:` or `fix:` commit, OR `gh run rerun --failed 25064401654` after retagging)
- [ ] Watch docker job tag the image with the bumped version
- [ ] Watch mcp-registry job successfully publish to https://registry.modelcontextprotocol.io