### PR TITLE
fix(companies): correct field names + add missing billing/invoice/quote fields on update_company

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -93,7 +93,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_update_company',
-    description: 'Update an existing company in Autotask. Supports the core identity fields (companyName, phone, address1, city, state, postalCode, isActive) plus extended fields: webAddress, paymentTerm, taxRegionID, invoiceTemplateID, taxID, taxExempt, ownerResourceID, classification, companyType. Field names match the Autotask REST API exactly (camelCase, capital ID suffixes where applicable).',
+    description: 'Update an existing company in Autotask. Field names match the Autotask REST API exactly (camelCase, capital ID suffixes where applicable). Note: Autotask uses invoiceTemplateID for payment terms (e.g. 103=Due on Receipt, 104=NET 30) — there is NO `paymentTerm` field on the Companies entity. Billing address fields (billingAddress1/billToCity/billToState/billToZipCode/billToCountryID/billToAttention/billToAddressToUse) are SEPARATE from the regular address fields (address1/city/state/postalCode/countryID) — set both pairs when needed.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -111,7 +111,11 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         },
         address1: {
           type: 'string',
-          description: 'Company address line 1'
+          description: 'Company address line 1 (the regular address, distinct from billingAddress1 used for invoices)'
+        },
+        address2: {
+          type: 'string',
+          description: 'Company address line 2'
         },
         city: {
           type: 'string',
@@ -125,6 +129,10 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'string',
           description: 'Company postal/ZIP code'
         },
+        countryID: {
+          type: 'number',
+          description: 'Country ID (e.g. 237 for United States)'
+        },
         isActive: {
           type: 'boolean',
           description: 'Whether the company is active'
@@ -133,26 +141,82 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'string',
           description: 'Company website URL (Autotask field name is webAddress, not website)'
         },
-        paymentTerm: {
-          type: 'number',
-          description: 'Payment term picklist ID'
+        // ---- Billing-to fields (used for Invoice Settings; SEPARATE from regular address) ----
+        billingAddress1: {
+          type: 'string',
+          description: 'Billing address line 1 (used for Invoice Settings — separate from address1)'
         },
+        billingAddress2: {
+          type: 'string',
+          description: 'Billing address line 2'
+        },
+        billToAttention: {
+          type: 'string',
+          description: 'Bill-to attention name'
+        },
+        billToAddressToUse: {
+          type: 'number',
+          description: 'Address-to-use flag (1 = use bill-to fields explicitly)'
+        },
+        billToCity: {
+          type: 'string',
+          description: 'Bill-to city'
+        },
+        billToState: {
+          type: 'string',
+          description: 'Bill-to state/province'
+        },
+        billToZipCode: {
+          type: 'string',
+          description: 'Bill-to ZIP/postal code'
+        },
+        billToCountryID: {
+          type: 'number',
+          description: 'Bill-to country ID'
+        },
+        billToCompanyLocationID: {
+          type: 'number',
+          description: 'Bill-to company location ID'
+        },
+        // ---- Tax / invoice settings ----
         taxRegionID: {
           type: 'number',
           description: 'Tax region ID (capital ID suffix per Autotask convention)'
         },
         invoiceTemplateID: {
           type: 'number',
-          description: 'Invoice template ID applied to this company'
+          description: 'Invoice template ID applied to this company. Acts as the payment-terms selector (e.g. 103=Due on Receipt, 104=NET 30).'
+        },
+        invoiceMethod: {
+          type: 'number',
+          description: 'Invoice delivery method picklist ID (e.g. 2=Email)'
+        },
+        invoiceEmailMessageID: {
+          type: 'number',
+          description: 'Default email-message template ID used when invoicing this company'
         },
         taxID: {
           type: 'string',
-          description: 'Tax registration / VAT identifier string'
+          description: 'Tax registration / FEIN / VAT identifier string'
         },
-        taxExempt: {
+        isTaxExempt: {
           type: 'boolean',
-          description: 'Whether the company is tax-exempt'
+          description: 'Whether the company is tax-exempt. Note: Autotask field name is `isTaxExempt` — not `taxExempt`.'
         },
+        // ---- Quote / PO templates ----
+        quoteEmailMessageID: {
+          type: 'number',
+          description: 'Default email-message template ID used when sending quotes'
+        },
+        quoteTemplateID: {
+          type: 'number',
+          description: 'Default quote template ID for this company'
+        },
+        purchaseOrderTemplateID: {
+          type: 'number',
+          description: 'Default purchase-order template ID for this company'
+        },
+        // ---- Ownership / classification ----
         ownerResourceID: {
           type: 'number',
           description: 'Resource ID of the account owner'


### PR DESCRIPTION
## Summary

Fixes silent-no-op bugs in `autotask_update_company` (introduced/expanded in #73) where field names on the MCP tool def don't match Autotask's REST API field names. Autotask silently ignores unknown fields, so PATCHes with the wrong name return 200 OK without updating anything — which is worse than a 4xx error because callers can't tell.

Also adds the bill-to address fields and invoice-method fields that #73 didn't expose, which are needed to fully configure a company's invoicing profile.

## What changed

- **Renamed `taxExempt` → `isTaxExempt`** (Autotask field is `isTaxExempt`; old name silently no-ops)
- **Removed `paymentTerm`** (no such field on Autotask Companies — Autotask uses `invoiceTemplateID` for payment terms; e.g., 103=Due on Receipt, 104=NET 30)
- **Added bill-to address fields** as separate from the regular address: `billingAddress1`, `billingAddress2`, `billToAttention`, `billToAddressToUse`, `billToCity`, `billToState`, `billToZipCode`, `billToCountryID`, `billToCompanyLocationID`
- **Added invoice/quote delivery fields**: `invoiceMethod`, `invoiceEmailMessageID`, `quoteEmailMessageID`, `quoteTemplateID`, `purchaseOrderTemplateID`
- **Added `countryID`** for the regular address (was missing)

## Why this matters

Without the rename, any caller setting `taxExempt: true` will think they marked the company tax-exempt but Autotask ignores the field. Discovered while productionizing an MSP onboarding routine — the company appeared to update successfully (HTTP 200) but tax-exempt status never flipped.

Same issue with bill-to fields: callers who tried to set the billing address separate from the shipping address through #73 had no way to do so because the bill-to* fields weren't exposed.

## Verification

- Tool def changes only — 1 file (`src/handlers/tool.definitions.ts`), 80 lines added, 8 changed.
- Live-tested against an Autotask sandbox: `isTaxExempt: true` now actually flips the flag; `billingAddress1` + `billToCity` etc. now persist as separate bill-to address.

## Field-name reference

The Autotask REST docs at `/Companies/entityInformation/fields` (queryable on any tenant) confirm:
- `isTaxExempt` (boolean, not `taxExempt`)
- `billingAddress1`, `billingAddress2`, `billToAttention`, `billToAddressToUse`, `billToCity`, `billToState`, `billToZipCode`, `billToCountryID`, `billToCompanyLocationID` — all present and writable
- `invoiceMethod` (integer picklist; 2=Email is most common)
- No `paymentTerm` field exists; payment terms live on `invoiceTemplateID`