### PR TITLE
Add destructive-action warnings to mutating tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Run linter
         run: npm run lint
         continue-on-error: true
-      
+
+      - name: Lint destructive tool warnings
+        run: node scripts/lint-destructive-warnings.mjs src
+
       - name: Build
         run: npm run build
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,13 +32,16 @@ jobs:
       
       - name: Run linter
         run: npm run lint
-      
+
+      - name: Lint destructive tool warnings
+        run: node scripts/lint-destructive-warnings.mjs src
+
       - name: Build
         run: npm run build
-      
+
       - name: Run tests
         run: npm test
-      
+
       - name: Test Docker build
         run: docker build --platform linux/amd64 -t autotask-mcp:test .
 
@@ -61,10 +64,13 @@ jobs:
       
       - name: Run linter
         run: npm run lint
-      
+
+      - name: Lint destructive tool warnings
+        run: node scripts/lint-destructive-warnings.mjs src
+
       - name: Build
         run: npm run build
-      
+
       - name: Run tests with coverage
         run: npm run test:coverage
       

--- a/scripts/lint-destructive-warnings.mjs
+++ b/scripts/lint-destructive-warnings.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Lint MCP tool definitions for missing destructive-action warnings.
+// Usage: node scripts/lint-destructive-warnings.mjs [path ...]
+// Exits 1 if any tool whose name matches a destructive verb lacks both
+// (a) a "⚠ DESTRUCTIVE" or "⚠ HIGH-IMPACT" prefix in its description, AND
+// (b) annotations.destructiveHint: true.
+//
+// Convention: see ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DESTRUCTIVE_VERBS = [
+  'delete', 'remove', 'destroy', 'wipe', 'purge', 'drop',
+  'disable', 'deactivate', 'suspend',
+  'revoke', 'reset_password', 'reset_mfa',
+  'offboard', 'terminate',
+  'archive', 'unarchive',
+  'quarantine_delete', 'quarantine_release',
+];
+
+const SKIP_PATTERNS = [
+  /_dropdown\b/, /_list\b/, /_search\b/, /_get\b/,
+  /quarantine_list/, /quarantine_search/,
+  /messages_blocked/, /clicks_blocked/,
+];
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', '__tests__', '.git', 'docs', 'docs-repo']);
+
+function* walk(dir) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      yield* walk(full);
+    } else if (
+      entry.endsWith('.ts') &&
+      !entry.endsWith('.d.ts') &&
+      !entry.endsWith('.test.ts')
+    ) {
+      yield full;
+    }
+  }
+}
+
+const roots = process.argv.slice(2);
+if (roots.length === 0) roots.push('.');
+
+let violations = 0;
+
+for (const root of roots) {
+  for (const file of walk(resolve(root))) {
+    const src = readFileSync(file, 'utf8');
+    const nameRegex = /name:\s*['"]([a-zA-Z0-9_]+)['"]/g;
+    let match;
+    while ((match = nameRegex.exec(src)) !== null) {
+      const toolName = match[1];
+      const lower = toolName.toLowerCase();
+
+      if (SKIP_PATTERNS.some(p => p.test(lower))) continue;
+      if (!DESTRUCTIVE_VERBS.some(v => lower.includes(v))) continue;
+
+      const window = src.slice(match.index, match.index + 1200);
+      const hasWarningPrefix = /⚠\s*(DESTRUCTIVE|HIGH-IMPACT)/.test(window);
+      const hasDestructiveHint = /destructiveHint\s*:\s*true/.test(window);
+
+      if (!hasWarningPrefix || !hasDestructiveHint) {
+        violations++;
+        const lineNum = src.slice(0, match.index).split('\n').length;
+        const missing = [
+          !hasWarningPrefix && 'description prefix (⚠ DESTRUCTIVE/HIGH-IMPACT)',
+          !hasDestructiveHint && 'annotations.destructiveHint: true',
+        ].filter(Boolean).join(' + ');
+        console.error(`${file}:${lineNum}  ${toolName}  missing: ${missing}`);
+      }
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(`\n${violations} destructive tool(s) missing warnings.`);
+  console.error('See ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b for the convention.');
+  process.exit(1);
+}
+console.log('All destructive tools carry the required warnings.');

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -770,7 +770,17 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_delete_ticket_charge',
-    description: 'Delete a ticket charge by ID. Requires both the parent ticket ID and charge ID.',
+    description:
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently deletes a ticket charge ' +
+      'record and all associated billing data. This action cannot be undone. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Delete ticket charge (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -1176,7 +1186,17 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_delete_ticket_checklist_item',
-    description: 'Delete a checklist item from a ticket.',
+    description:
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently deletes a checklist item ' +
+      'from a ticket. This action cannot be undone. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Delete ticket checklist item (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -1977,7 +1997,17 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_delete_quote_item',
-    description: 'Delete a quote item (line item) from a quote',
+    description:
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently deletes a quote item ' +
+      '(line item) from a quote. This action cannot be undone. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Delete quote item (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -2644,7 +2674,17 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_delete_service_call',
-    description: 'Delete a service call by ID',
+    description:
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently deletes a service call ' +
+      'and all associated data. This action cannot be undone. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Delete service call (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -2702,7 +2742,17 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_delete_service_call_ticket',
-    description: 'Remove a ticket association from a service call by the service call ticket record ID',
+    description:
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently removes a ticket ' +
+      'association from a service call. This action cannot be undone. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Delete service call ticket association (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -2764,7 +2814,17 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_delete_service_call_ticket_resource',
-    description: 'Remove a resource assignment from a service call ticket by the resource record ID',
+    description:
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently removes a resource ' +
+      'assignment from a service call ticket. This action cannot be undone. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Delete service call ticket resource assignment (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -52,6 +52,13 @@ export interface McpTool {
     properties: Record<string, any>;
     required?: string[];
   };
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
 }
 
 export interface McpToolResult {


### PR DESCRIPTION
## Summary

Applies the WYRE MCP destructive-tool warning convention (§2.7b — Tier A, irreversible) to the six `autotask_delete_*` tools, and adds a CI lint guard so future destructive tools cannot ship without warnings.

### Affected tools (Tier A — irreversible)

- `autotask_delete_ticket_charge`
- `autotask_delete_ticket_checklist_item`
- `autotask_delete_quote_item`
- `autotask_delete_service_call`
- `autotask_delete_service_call_ticket`
- `autotask_delete_service_call_ticket_resource`

Each now carries:
- A `⚠ DESTRUCTIVE — IRREVERSIBLE.` description prefix ending with "Confirm with the user before invoking."
- `annotations.destructiveHint: true` (with `readOnlyHint: false`, `idempotentHint: false`, `openWorldHint: true`).

### CI guard

- Adds `scripts/lint-destructive-warnings.mjs` (copied verbatim from `mcp-gateway`) that scans `src/` for tool names matching destructive verbs and fails if either the description prefix or `destructiveHint: true` is missing.
- Wires `node scripts/lint-destructive-warnings.mjs src` into `.github/workflows/test.yml` (both jobs) and `.github/workflows/release.yml`, immediately after the existing `npm run lint` step.

Note: per the convention, gray-area `update_*` operations are intentionally **not** flagged — they are routine.

Convention reference: WYRE MCP Destructive Tool Warning Convention §2.7b (`~/.claude/skills/mcp-vendor-scaffolding/SKILL.md`).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node scripts/lint-destructive-warnings.mjs src` passes locally
- [ ] CI `Run linter` + `Lint destructive tool warnings` steps pass on this PR