### PR TITLE
feat(tickets): expose TicketHistory audit trail as MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- **Ticket history audit-trail tools** (`autotask_get_ticket_history`, `autotask_search_ticket_history`). Exposes the Autotask `/TicketHistory` entity (GET-only) so callers can answer "when did this ticket transition from status X to status Y", "who changed the priority", etc. `search` requires a `ticketId` (Autotask does not support unscoped history queries) and fails fast with a friendly error before any network round-trip if it's missing. Surfaced via the `tickets` category bundle.
+
 ### Fixed
 
 - **`MappingService` company cache was silently truncated to 25 entries** — `refreshCompanyCache()` called `searchCompanies({})` assuming "no pageSize = fetch all pages", but the underlying `searchCompanies` defaults to `pageSize: 25, page: 1` and returns only the first page. The cache was then logged as `"COMPLETE dataset"`, which was incorrect.

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -797,6 +797,42 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     }
   },
 
+  // Ticket History tools (read-only audit trail of field changes)
+  {
+    name: 'autotask_get_ticket_history',
+    description: 'Get a single ticket history entry by ID. Each entry records one audited change to a ticket field (who, when, before/after).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        historyId: {
+          type: 'number',
+          description: 'The ticket history entry ID to retrieve'
+        }
+      },
+      required: ['historyId']
+    }
+  },
+  {
+    name: 'autotask_search_ticket_history',
+    description: 'Get the audit trail of field changes for a ticket (status transitions, assignment changes, priority edits, etc.). Use this to answer questions like "when did this ticket move from In Progress to Waiting Customer" or "who changed the priority". Returns entries ordered by Autotask; sort/filter client-side if needed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: {
+          type: 'number',
+          description: 'The ticket ID to get history for (required — Autotask does not support unscoped history queries)'
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Number of history entries to return (default: 50, max: 500)',
+          minimum: 1,
+          maximum: 500
+        }
+      },
+      required: ['ticketId']
+    }
+  },
+
   // Time entry tools
   {
     name: 'autotask_create_time_entry',
@@ -3003,8 +3039,8 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
     tools: ['autotask_search_contacts', 'autotask_create_contact']
   },
   tickets: {
-    description: 'Search, create, update tickets and manage ticket notes, attachments, and charges',
-    tools: ['autotask_search_tickets', 'autotask_get_ticket_details', 'autotask_create_ticket', 'autotask_update_ticket', 'autotask_get_ticket_note', 'autotask_search_ticket_notes', 'autotask_create_ticket_note', 'autotask_get_ticket_attachment', 'autotask_search_ticket_attachments', 'autotask_create_ticket_attachment', 'autotask_get_ticket_charge', 'autotask_search_ticket_charges', 'autotask_create_ticket_charge', 'autotask_update_ticket_charge', 'autotask_delete_ticket_charge']
+    description: 'Search, create, update tickets and manage ticket notes, attachments, charges, and audit history',
+    tools: ['autotask_search_tickets', 'autotask_get_ticket_details', 'autotask_create_ticket', 'autotask_update_ticket', 'autotask_get_ticket_note', 'autotask_search_ticket_notes', 'autotask_create_ticket_note', 'autotask_get_ticket_attachment', 'autotask_search_ticket_attachments', 'autotask_create_ticket_attachment', 'autotask_get_ticket_charge', 'autotask_search_ticket_charges', 'autotask_create_ticket_charge', 'autotask_update_ticket_charge', 'autotask_delete_ticket_charge', 'autotask_get_ticket_history', 'autotask_search_ticket_history']
   },
   projects: {
     description: 'Search and create projects, tasks, phases, and project notes',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -853,6 +853,17 @@ export class AutotaskToolHandler {
         return { result: a.chargeId, message: `Successfully deleted ticket charge ${a.chargeId}` };
       }],
 
+      // Ticket History (read-only audit trail)
+      ['autotask_get_ticket_history', async (a) => {
+        const r = await s.getTicketHistory(a.historyId);
+        if (!r) return { result: null, message: `No ticket history entry found with ID ${a.historyId}` };
+        return { result: r, message: 'Ticket history entry retrieved successfully' };
+      }],
+      ['autotask_search_ticket_history', async (a) => {
+        const r = await s.searchTicketHistory({ ticketId: a.ticketId, pageSize: a.pageSize });
+        return { result: r, message: `Found ${r.length} ticket history entries for ticket ${a.ticketId}` };
+      }],
+
       // Service Calls
       ['autotask_get_service_call', async (a) => {
         const r = await s.getServiceCall(a.serviceCallId);

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -40,6 +40,7 @@ import {
   AutotaskBillingItem,
   AutotaskBillingItemApprovalLevel,
   AutotaskTicketCharge,
+  AutotaskTicketHistory,
   AutotaskServiceCall,
   AutotaskServiceCallTicket,
   AutotaskServiceCallTicketResource,
@@ -476,6 +477,45 @@ export class AutotaskService {
       this.logger.info(`Ticket charge ${chargeId} deleted successfully`);
     } catch (error) {
       this.logger.error(`Failed to delete ticket charge ${chargeId}:`, error);
+      throw error;
+    }
+  }
+
+  // =====================================================
+  // Ticket History (read-only audit trail of field changes)
+  // =====================================================
+
+  async getTicketHistory(id: number): Promise<AutotaskTicketHistory | null> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug(`Getting ticket history entry with ID: ${id}`);
+      return await http.get<AutotaskTicketHistory>('TicketHistory', id);
+    } catch (error) {
+      this.logger.error(`Failed to get ticket history entry ${id}:`, error);
+      throw error;
+    }
+  }
+
+  async searchTicketHistory(options: AutotaskQueryOptionsExtended & { ticketId?: number } = {}): Promise<AutotaskTicketHistory[]> {
+    // Autotask requires a ticketID filter for TicketHistory queries — surface
+    // a friendly error instead of letting the API reject with a generic 400.
+    // Guard before ensureClient() so callers fail fast without a network round-trip.
+    if (!options.ticketId) {
+      throw new Error('ticketId is required to search ticket history');
+    }
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug('Searching ticket history with options:', options);
+      const filters: QueryFilter[] = [
+        { op: 'eq', field: 'ticketID', value: options.ticketId },
+      ];
+      return await http.query<AutotaskTicketHistory>(
+        'TicketHistory',
+        filters,
+        { maxRecords: Math.min(options.pageSize || 50, 500) }
+      );
+    } catch (error) {
+      this.logger.error('Failed to search ticket history:', error);
       throw error;
     }
   }

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -227,6 +227,17 @@ export interface AutotaskTicketChecklistItem {
   [key: string]: any;
 }
 
+// Read-only entity (GET only). Each row represents a single audited change to a
+// ticket field — value-before, value-after, who, when. Surface is intentionally
+// open-ended because Autotask returns a wide, picklist-dependent field set.
+export interface AutotaskTicketHistory {
+  id?: number;
+  ticketID?: number;
+  resourceID?: number;
+  dateChanged?: string;
+  [key: string]: any;
+}
+
 export interface AutotaskProjectNote {
   id?: number;
   projectID?: number;

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -160,6 +160,21 @@ describe('AutotaskService', () => {
       await expect(service.deleteTicketChecklistItem(123, 456)).rejects.toThrow();
     });
 
+    test('should expose ticket history methods and require ticketId for search', async () => {
+      const service = new AutotaskService(mockConfig, mockLogger);
+
+      expect(typeof service.getTicketHistory).toBe('function');
+      expect(typeof service.searchTicketHistory).toBe('function');
+
+      // Friendly guard fires before any HTTP attempt — verifies we don't leak
+      // a generic 400 from Autotask when the caller forgets ticketId.
+      await expect(service.searchTicketHistory({})).rejects.toThrow(/ticketId is required/);
+
+      // With the mocked client failing to initialize, real calls should reject.
+      await expect(service.getTicketHistory(456)).rejects.toThrow();
+      await expect(service.searchTicketHistory({ ticketId: 123 })).rejects.toThrow();
+    });
+
     test('should handle attachment methods with proper error messages', async () => {
       const service = new AutotaskService(mockConfig, mockLogger);
 


### PR DESCRIPTION
## Summary

Adds two read-only tools that surface the Autotask `/TicketHistory` entity (audit trail of every field change on a ticket — who, when, before/after):

- `autotask_get_ticket_history` — get one history entry by ID
- `autotask_search_ticket_history` — get all history entries for a given ticket

Reported via community feedback. A user attempting to trace ticket status transitions through Claude got back \"TicketHistory is not an exposed skill in the MCP Server\" — the entity existed in the underlying \`autotask-node\` SDK but had never been wired into the MCP tool surface. With this PR, Claude can now answer questions like \"when did this ticket move from In Progress to Waiting Customer\" or \"who changed the priority on T20240215.0042\" without forcing the user into the Autotask UI.

## Design notes

- **`ticketId` is required for search.** Autotask's REST API does not support unscoped history queries. The guard fires *before* `ensureClient()` so callers fail fast with a friendly error rather than incurring a network round-trip and a generic 400.
- **Open-ended type.** `AutotaskTicketHistory` carries only the well-known fields (`id`, `ticketID`, `resourceID`, `dateChanged`) plus `[key: string]: any` — the actual field set returned per row is picklist- and tenant-dependent (e.g., `oldValue`/`newValue` columns reference picklist IDs that vary per Autotask instance).
- **Surfaced via the `tickets` category bundle** so callers using \`autotask_list_category_tools\` discover it.
- **No write path.** The underlying entity is GET-only per the Autotask spec.

## Files changed

| File | What |
|------|------|
| `src/types/autotask.ts` | New `AutotaskTicketHistory` interface |
| `src/services/autotask.service.ts` | `getTicketHistory()`, `searchTicketHistory()` |
| `src/handlers/tool.definitions.ts` | Two new tool defs + add to `tickets` category |
| `src/handlers/tool.handler.ts` | Dispatcher entries |
| `tests/autotask-service.test.ts` | Smoke tests + verifies `ticketId` guard fires before any HTTP attempt |
| `CHANGELOG.md` | `### Added` entry in `[Unreleased]` |

## Follow-up

A companion PR will land in `wyre-technology/msp-claude-plugins` to update the `kaseya/autotask/skills/tickets/SKILL.md` skill so Claude actually reaches for these tools when users ask status-transition questions — without that, the tools exist but the skill won't suggest them. Will link here once opened.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 79/79 passing (including new ticket-history smoke tests)
- [x] `npm run lint` — 0 errors (warnings unchanged from baseline)
- [x] New test verifies the `ticketId` required-guard fires *before* `ensureClient()` (no network attempt without it)