### PR TITLE
fix(release): re-pin shared deploy workflow to d6ace52

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     # Delegates to the canonical reusable workflow so the digest-pinned + correct-ACA
     # deploy logic lives in one place across every wyre-technology/*-mcp repo.
-    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@c2d6fc89211757997102d100115d02997d4e3521
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@d6ace529b210900f460cb365529f2a552daedf7a
     with:
       vendor-slug: autotask
       image-name: ghcr.io/wyre-technology/autotask-mcp


### PR DESCRIPTION
Previous pin `c2d6fc8` had a workflow-load failure: an input description contained a literal `\${{ needs.docker.outputs.digest }}` expression, which GitHub Actions evaluates at load time when `needs` isn't a defined context. Every fleet release pipeline failed validation with 0 jobs on the post-rollout run.

Fixed in wyre-technology/.github#12 (merge commit `d6ace529b210900f460cb365529f2a552daedf7a`). This PR bumps the pin to the fixed SHA so this repo's release pipeline can actually execute the deploy job.

## Test plan

- [x] YAML parses
- [ ] Next push-to-main release lands the deploy on `gwp-<vendor>` by digest (the original "once and for all" goal)