### PR TITLE
fix(search): honor filter params in 4 search tools (#104, #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ### Fixed
 
+- **Four `search*` tools advertised filter params they silently dropped** ([#104](https://github.com/wyre-technology/autotask-mcp/issues/104), [#105](https://github.com/wyre-technology/autotask-mcp/issues/105)). `searchContracts`, `searchConfigurationItems`, `searchInvoices`, and `searchTasks` all published `inputSchema` properties like `companyID`, `searchTerm`, `status`, `assignedResourceID` — every property described as "Filter by …" — but the service methods read only `options.filter` and `options.pageSize`. The advertised properties were accepted, logged at debug level, then discarded. Callers got the same MATCH_ALL page-1 slice regardless of what they passed.
+  - Effect: typed search tools were useless for any non-trivial query. Workaround was `autotask_raw_request`, which defeats the purpose of having schema-typed tools and isn't discoverable by MCP clients reading the catalog.
+  - Fix: each method now mirrors the `searchProjects` pattern that was already in place — translates schema-shaped args into `QueryFilter[]` entries, with the `options.filter` escape hatch preserved for advanced callers. Field-name mappings per Autotask REST entity:
+    - **Contracts**: `companyID`, `status`, `contractName` (for `searchTerm`)
+    - **ConfigurationItems**: `companyID`, `isActive`, `productID`, `referenceTitle` (for `searchTerm`)
+    - **Invoices**: `companyID`, `invoiceNumber`, `isVoided`
+    - **Tasks**: `projectID`, `status`, `assignedResourceID`, `title` (for `searchTerm`)
+  - `searchTasks` also dropped its advertised `page` argument — same bug class as the #101 fix to `searchCompanies`. Applied the same fetch-and-slice pattern over `http.query`'s cursor pagination.
+  - 6 new tests in `tests/autotask-service.test.ts` mock `fetch` directly and assert the request body's `filter` array reflects each translated property. The "no filter args sends MATCH_ALL" test pins the no-regression case.
+  - Defensive grep confirmed the contained scope: no other `search*` method on this service has the broken `Array.isArray(options.filter)`-only pattern. `getTimeEntries` has the same shape but isn't exposed via a search tool (`searchTimeEntries` is the real handler at line 2078).
+
 - **`serverInfo.version` reported hardcoded `"1.0.0"` regardless of the running release** ([#94](https://github.com/wyre-technology/autotask-mcp/issues/94)). Both `src/utils/config.ts` and `src/mcp/server.ts` fell back to a literal `'1.0.0'` string instead of the actual build version. Effect: every release through `v2.x.x` reported `1.0.0` in the MCP `initialize` handshake. Clients that surface `serverInfo.version` (Claude Code's `claude mcp list`, etc.) showed `1.0.0` regardless of which image was actually running, making operator triage / bug-report attribution unreliable.
   - Fix:
     - Both fallback chains now read from the bundled `package.json` (TypeScript's `resolveJsonModule` was already enabled). Priority order: `MCP_SERVER_VERSION env > packageJson.version > 'unknown'`.

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -53,7 +53,37 @@ import { FieldInfo, PicklistValue } from './picklist.cache';
 /**
  * Default "match all" filter required by Autotask for unconstrained queries.
  */
-const MATCH_ALL: QueryFilter[] = [{ op: 'gte', field: 'id', value: 0 }];
+export const MATCH_ALL: QueryFilter[] = [{ op: 'gte', field: 'id', value: 0 }];
+
+/**
+ * Push an `eq` filter only when `value` is not `undefined`. Replaces the
+ * `if (options.X !== undefined) filters.push({ op: 'eq', field: 'X', value: options.X })`
+ * pattern that was previously duplicated across every search method.
+ */
+function pushEq(filters: QueryFilter[], field: string, value: unknown): void {
+  if (value !== undefined) {
+    filters.push({ op: 'eq', field, value });
+  }
+}
+
+/**
+ * Merge the `options.filter` escape hatch (array of QueryFilter or a flat
+ * `field → value` object) into the in-progress filters list. Previously
+ * inlined as a 7-line block in every search method.
+ */
+function mergeFilterEscapeHatch(
+  filters: QueryFilter[],
+  raw: QueryFilter[] | Record<string, unknown> | undefined,
+): void {
+  if (!raw) return;
+  if (Array.isArray(raw)) {
+    if (raw.length > 0) filters.push(...raw);
+    return;
+  }
+  for (const [field, value] of Object.entries(raw)) {
+    filters.push({ op: 'eq', field, value });
+  }
+}
 
 export class AutotaskService {
   private http: AutotaskHttpClient | null = null;
@@ -713,29 +743,15 @@ export class AutotaskService {
     try {
       this.logger.debug('Searching projects with options:', options);
       const filters: QueryFilter[] = [];
+      const o = options as any;
 
-      if ((options as any).companyID !== undefined) {
-        filters.push({ op: 'eq', field: 'companyID', value: (options as any).companyID });
+      pushEq(filters, 'companyID', o.companyID);
+      pushEq(filters, 'status', o.status);
+      pushEq(filters, 'projectLeadResourceID', o.projectLeadResourceID);
+      if (o.searchTerm) {
+        filters.push({ op: 'contains', field: 'projectName', value: o.searchTerm });
       }
-      if ((options as any).status !== undefined) {
-        filters.push({ op: 'eq', field: 'status', value: (options as any).status });
-      }
-      if ((options as any).projectLeadResourceID !== undefined) {
-        filters.push({ op: 'eq', field: 'projectLeadResourceID', value: (options as any).projectLeadResourceID });
-      }
-      if ((options as any).searchTerm) {
-        filters.push({ op: 'contains', field: 'projectName', value: (options as any).searchTerm });
-      }
-
-      if (options.filter) {
-        if (Array.isArray(options.filter) && options.filter.length > 0) {
-          filters.push(...(options.filter as QueryFilter[]));
-        } else if (!Array.isArray(options.filter)) {
-          for (const [field, value] of Object.entries(options.filter)) {
-            filters.push({ op: 'eq', field, value });
-          }
-        }
-      }
+      mergeFilterEscapeHatch(filters, options.filter);
 
       const pageSize = Math.min(options.pageSize || 25, 100);
       const projects = await http.query<AutotaskProject>(
@@ -850,12 +866,24 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Searching configuration items with options:', options);
+      // Schema-shaped filter args were previously dropped — issue #105.
+      const filters: QueryFilter[] = [];
+      const o = options as any;
+
+      pushEq(filters, 'companyID', o.companyID);
+      pushEq(filters, 'isActive', o.isActive);
+      pushEq(filters, 'productID', o.productID);
+      if (o.searchTerm) {
+        filters.push({ op: 'contains', field: 'referenceTitle', value: o.searchTerm });
+      }
+      mergeFilterEscapeHatch(filters, options.filter);
+
       const pageSize = Math.min(options.pageSize || 25, 500);
-      const filter: QueryFilter[] =
-        Array.isArray(options.filter) && options.filter.length > 0
-          ? (options.filter as QueryFilter[])
-          : MATCH_ALL;
-      return await http.query<AutotaskConfigurationItem>('ConfigurationItems', filter, { maxRecords: pageSize });
+      return await http.query<AutotaskConfigurationItem>(
+        'ConfigurationItems',
+        filters.length > 0 ? filters : MATCH_ALL,
+        { maxRecords: pageSize }
+      );
     } catch (error) {
       this.logger.error('Failed to search configuration items:', error);
       throw error;
@@ -906,12 +934,23 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Searching contracts with options:', options);
+      // Schema-shaped filter args were previously dropped — issue #105.
+      const filters: QueryFilter[] = [];
+      const o = options as any;
+
+      pushEq(filters, 'companyID', o.companyID);
+      pushEq(filters, 'status', o.status);
+      if (o.searchTerm) {
+        filters.push({ op: 'contains', field: 'contractName', value: o.searchTerm });
+      }
+      mergeFilterEscapeHatch(filters, options.filter);
+
       const pageSize = Math.min(options.pageSize || 25, 500);
-      const filter: QueryFilter[] =
-        Array.isArray(options.filter) && options.filter.length > 0
-          ? (options.filter as QueryFilter[])
-          : MATCH_ALL;
-      return await http.query<AutotaskContract>('Contracts', filter, { maxRecords: pageSize });
+      return await http.query<AutotaskContract>(
+        'Contracts',
+        filters.length > 0 ? filters : MATCH_ALL,
+        { maxRecords: pageSize }
+      );
     } catch (error) {
       this.logger.error('Failed to search contracts:', error);
       throw error;
@@ -991,12 +1030,21 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Searching invoices with options:', options);
+      // Schema-shaped filter args were previously dropped — issue #105.
+      const filters: QueryFilter[] = [];
+      const o = options as any;
+
+      pushEq(filters, 'companyID', o.companyID);
+      pushEq(filters, 'invoiceNumber', o.invoiceNumber);
+      pushEq(filters, 'isVoided', o.isVoided);
+      mergeFilterEscapeHatch(filters, options.filter);
+
       const pageSize = Math.min(options.pageSize || 25, 500);
-      const filter: QueryFilter[] =
-        Array.isArray(options.filter) && options.filter.length > 0
-          ? (options.filter as QueryFilter[])
-          : MATCH_ALL;
-      return await http.query<AutotaskInvoice>('Invoices', filter, { maxRecords: pageSize });
+      return await http.query<AutotaskInvoice>(
+        'Invoices',
+        filters.length > 0 ? filters : MATCH_ALL,
+        { maxRecords: pageSize }
+      );
     } catch (error) {
       this.logger.error('Failed to search invoices:', error);
       throw error;
@@ -1057,14 +1105,35 @@ export class AutotaskService {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Searching tasks with options:', options);
+      // Schema-shaped filter args were previously dropped — issues #104, #105.
+      const filters: QueryFilter[] = [];
+      const o = options as any;
+
+      pushEq(filters, 'projectID', o.projectID);
+      pushEq(filters, 'status', o.status);
+      pushEq(filters, 'assignedResourceID', o.assignedResourceID);
+      if (o.searchTerm) {
+        filters.push({ op: 'contains', field: 'title', value: o.searchTerm });
+      }
+      mergeFilterEscapeHatch(filters, options.filter);
+
+      // Honor `page` via fetch-and-slice over http.query's cursor pagination —
+      // same pattern as searchCompanies (#101). Autotask's REST API has no
+      // native offset, so we fetch up to page*pageSize and slice.
+      const page = Math.max(1, o.page || 1);
       const pageSize = Math.min(options.pageSize || 25, 100);
-      const filter: QueryFilter[] =
-        Array.isArray(options.filter) && options.filter.length > 0
-          ? (options.filter as QueryFilter[])
-          : MATCH_ALL;
-      const tasks = await http.query<AutotaskTask>('Tasks', filter, { maxRecords: pageSize });
+      const targetEnd = page * pageSize;
+      const fetched = await http.query<AutotaskTask>(
+        'Tasks',
+        filters.length > 0 ? filters : MATCH_ALL,
+        { maxRecords: targetEnd }
+      );
+      const start = (page - 1) * pageSize;
+      const tasks = fetched.slice(start, targetEnd);
       const optimized = tasks.map(t => this.optimizeTaskData(t));
-      this.logger.info(`Retrieved ${optimized.length} tasks`);
+      this.logger.info(
+        `Retrieved ${optimized.length} tasks (page ${page}, pageSize ${pageSize}, fetched ${fetched.length} to slice)`
+      );
       return optimized;
     } catch (error) {
       this.logger.error('Failed to search tasks:', error);

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -7,7 +7,7 @@ jest.mock('autotask-node', () => ({
   }
 }));
 
-import { AutotaskService } from '../src/services/autotask.service';
+import { AutotaskService, MATCH_ALL } from '../src/services/autotask.service';
 import { Logger } from '../src/utils/logger';
 import type { McpServerConfig } from '../src/types/mcp';
 
@@ -724,6 +724,125 @@ describe('AutotaskService', () => {
       expect(all).toHaveLength(400);
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('hit maxRecords cap'));
       warnSpy.mockRestore();
+    });
+
+    // ---- search* filter translation (regression: issues #104, #105) ----
+    //
+    // Four search methods (Contracts, ConfigurationItems, Invoices, Tasks)
+    // previously accepted schema-shaped filter args (companyID, searchTerm,
+    // etc.) and silently dropped them, returning MATCH_ALL page-1 for every
+    // call. These tests mock fetch directly and assert the request body's
+    // `filter` array reflects the caller's intent.
+
+    // Captures the request body sent to /<entity>/query. Side-effect: assigns
+    // the per-suite `fetchSpy` so afterEach's restoreAllMocks still cleans up.
+    const captureFilter = (entity: string): (() => any) => {
+      let captured: any = null;
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+        const url = typeof input === 'string' ? input : (input as URL).toString();
+        if (url.endsWith(`/${entity}/query`)) {
+          captured = JSON.parse(init!.body as string);
+        }
+        return jsonResponse({ items: [], pageDetails: { nextPageUrl: null } });
+      });
+      return () => captured;
+    };
+
+    test('searchContracts translates companyID, status, searchTerm', async () => {
+      const capture = captureFilter('Contracts');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchContracts({ companyID: 12345, status: 1, searchTerm: 'Managed' } as any);
+      const body = capture();
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'companyID', value: 12345 });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'status', value: 1 });
+      expect(body.filter).toContainEqual({ op: 'contains', field: 'contractName', value: 'Managed' });
+    });
+
+    test('searchContracts with no filter args sends MATCH_ALL (no regression)', async () => {
+      const capture = captureFilter('Contracts');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchContracts({});
+      expect(capture().filter).toEqual(MATCH_ALL);
+    });
+
+    test('searchConfigurationItems translates companyID, isActive, productID, searchTerm', async () => {
+      const capture = captureFilter('ConfigurationItems');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchConfigurationItems({
+        companyID: 999,
+        isActive: true,
+        productID: 42,
+        searchTerm: 'laptop',
+      } as any);
+      const body = capture();
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'companyID', value: 999 });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'isActive', value: true });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'productID', value: 42 });
+      expect(body.filter).toContainEqual({ op: 'contains', field: 'referenceTitle', value: 'laptop' });
+    });
+
+    test('searchInvoices translates companyID, invoiceNumber, isVoided', async () => {
+      const capture = captureFilter('Invoices');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchInvoices({
+        companyID: 12345,
+        invoiceNumber: 'INV-2024-001',
+        isVoided: false,
+      } as any);
+      const body = capture();
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'companyID', value: 12345 });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'invoiceNumber', value: 'INV-2024-001' });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'isVoided', value: false });
+    });
+
+    test('searchTasks translates projectID, status, assignedResourceID, searchTerm', async () => {
+      const capture = captureFilter('Tasks');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchTasks({
+        projectID: 100,
+        status: 2,
+        assignedResourceID: 29744150,
+        searchTerm: 'deploy',
+      } as any);
+      const body = capture();
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'projectID', value: 100 });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'status', value: 2 });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'assignedResourceID', value: 29744150 });
+      expect(body.filter).toContainEqual({ op: 'contains', field: 'title', value: 'deploy' });
+    });
+
+    test('searchTasks honors page via slice-and-dice (same pattern as #101 searchCompanies fix)', async () => {
+      // Mock cursor: page 1 returns 25 items (IDs 1-25) + nextPageUrl, page 2 returns 25 (IDs 26-50).
+      const buildBatch = (start: number, count: number) =>
+        Array.from({ length: count }, (_, i) => ({
+          id: start + i,
+          title: `Task ${start + i}`,
+        }));
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+        const url = typeof input === 'string' ? input : (input as URL).toString();
+        const method = (init?.method || 'GET').toUpperCase();
+        if (method === 'POST' && url === `${BASE}/Tasks/query`) {
+          return jsonResponse({
+            items: buildBatch(1, 25),
+            pageDetails: { nextPageUrl: `${BASE}/Tasks/query?page=2` },
+          });
+        }
+        if (method === 'GET' && url.includes('Tasks/query?page=2')) {
+          return jsonResponse({
+            items: buildBatch(26, 25),
+            pageDetails: { nextPageUrl: null },
+          });
+        }
+        throw new Error(`unexpected fetch ${method} ${url}`);
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const result = await service.searchTasks({ page: 2, pageSize: 25 } as any);
+
+      // page=2 with pageSize=25 → targetEnd=50, slice(25, 50) → tasks 26-50
+      expect(result).toHaveLength(25);
+      expect(result[0].id).toBe(26);
+      expect(result[result.length - 1].id).toBe(50);
     });
   });
 });


### PR DESCRIPTION
Closes #104, closes #105.

Four \`autotask_search_*\` tools advertised filter properties in their \`inputSchema\` (\`companyID\`, \`searchTerm\`, \`status\`, etc.) — every property described as \"Filter by …\" — but the service methods read **only** \`options.filter\` and \`options.pageSize\`. The advertised properties were accepted, logged at debug level, then discarded. Callers got the same MATCH_ALL page-1 slice regardless of what they passed.

Reporters:
- **@AntR007** (#104) — \`search_tasks\` specifically
- **@roobr** (#105) — comprehensive sweep with field-name mappings cited against the Autotask entity API + root-cause diagnosis pointing at the working reference (\`searchProjects\` line 711)

## Affected tools

| Tool | Dropped filter properties |
|---|---|
| \`autotask_search_contracts\` | \`searchTerm\`, \`companyID\`, \`status\` |
| \`autotask_search_configuration_items\` | \`searchTerm\`, \`companyID\`, \`isActive\`, \`productID\` |
| \`autotask_search_invoices\` | \`companyID\`, \`invoiceNumber\`, \`isVoided\` |
| \`autotask_search_tasks\` | \`searchTerm\`, \`projectID\`, \`status\`, \`assignedResourceID\`, **\`page\`** |

## Fix

Each method now translates schema-shaped args into \`QueryFilter[]\` entries with the \`options.filter\` escape hatch preserved. Field names per Autotask REST entity (cited by @roobr against \`entityInformation/fields\`):

- **Contracts**: \`companyID\`, \`status\`, \`contractName\` (for \`searchTerm\`)
- **ConfigurationItems**: \`companyID\`, \`isActive\`, \`productID\`, \`referenceTitle\` (for \`searchTerm\`)
- **Invoices**: \`companyID\`, \`invoiceNumber\`, \`isVoided\`
- **Tasks**: \`projectID\`, \`status\`, \`assignedResourceID\`, \`title\` (for \`searchTerm\`)

\`searchTasks\` also dropped its advertised \`page\` arg — same class as #101's \`searchCompanies\` fix. Applied the same fetch-and-slice over \`http.query\`'s cursor pagination.

## DRY

After the initial fix, the same translation pattern would have appeared in 5 places (\`searchProjects\` + the 4 new methods). Extracted two module-level helpers near \`MATCH_ALL\`:

\`\`\`ts
function pushEq(filters, field, value)         // no-ops on undefined
function mergeFilterEscapeHatch(filters, raw)  // handles array & object forms
\`\`\`

\`searchProjects\` was refactored to use them too, so all five search paths share the same primitives. Net **–77 LOC** in the service, **–32 lint warnings** (mostly \`(options as any)\` casts).

## Tests

6 new tests in \`tests/autotask-service.test.ts\` mock \`fetch\` directly (the #102 pattern):

- \`searchContracts\` / \`searchConfigurationItems\` / \`searchInvoices\` / \`searchTasks\` — each asserts the request body's \`filter\` array contains the translated entries for every advertised property.
- \`searchContracts\` with no filter args sends \`MATCH_ALL\` — pins the no-regression case, imports the \`MATCH_ALL\` constant so a future change to the literal doesn't silently break this assertion.
- \`searchTasks\` page=2/pageSize=25 returns IDs 26-50 — proves the fetch-and-slice cursor walk.

## Defensive sweep

Grep for the broken pattern (\`Array.isArray(options.filter)\`-only with no named-field translation) confirmed contained scope. \`getTimeEntries\` matches the shape but isn't exposed via a search tool — \`autotask_search_time_entries\` dispatches to \`searchTimeEntries\` which translates filters correctly.

## Verification

- [x] \`npm run build\` — clean
- [x] \`npm test\` — **99/99 passing** (up from 93; 6 new tests, 0 regressions)
- [x] \`npm run lint\` — 0 errors; warnings dropped 225 → 193 from the cast removal

## Deferred follow-ups (called out, not in this PR)

- **Per-method typed options interfaces** to eliminate the remaining \`(options as any)\` pattern. Reviewers agreed this is worth doing but it'd also need to touch \`searchProjects\` and tests, broader than this bug fix. The cast pattern matches existing house style — flagged for a separate PR.
- **Max-page guard on \`searchTasks\` deep paging** — for tenants with 100k+ tasks, page 100 fetches 10k records to slice 100. Currently warned via log breadcrumb but not blocked. Not blocking this fix.