### PR TITLE
feat(rate-limit): surface Autotask 429/threshold errors as structured (#69, #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### Added
 
+- **Structured rate-limit handling for Autotask API thresholds** ([#69](https://github.com/wyre-technology/autotask-mcp/issues/69), [#91](https://github.com/wyre-technology/autotask-mcp/issues/91)). Previously, when Autotask returned HTTP 429 (per-integration API threshold exceeded — ~10k req/hr soft, ~20k hard), the response bubbled up as a generic `Error` indistinguishable from a 500 or any other failure. LLM-driven workflows that fan out (e.g. "status report for all open projects with notes" — the canonical scenario @faspina reported) kept retrying the same expensive path while the user got threshold-exceeded emails from Autotask and saw disconnects.
+  - New `AutotaskRateLimitError` (exported from `src/services/autotask-http.ts`) is thrown specifically on HTTP 429. Carries `retryAfterSeconds` parsed from the `Retry-After` response header (RFC 7231 — integer seconds or HTTP-date supported, falls back to 60s when missing/unparseable).
+  - `AutotaskToolHandler.callTool` recognizes the typed error and returns a structured tool result with `error_type: "rate_limited"`, `retry_after_seconds`, and an explicit `instruction` field telling the LLM not to retry. Belt-and-suspenders for clients that don't parse `error_type` programmatically.
+  - 5 new tests in `tests/rate-limit.test.ts` cover Retry-After parsing (integer, missing, garbage), non-429 errors staying as generic `Error`, and end-to-end propagation to the structured tool envelope.
+
+- **Rate-limit scoping hints on fan-out tool descriptions.** Tools that LLMs commonly loop over (`autotask_search_ticket_notes`, `autotask_search_project_notes`, `autotask_search_company_notes`, `autotask_search_time_entries`, `autotask_search_ticket_attachments`) now include a "RATE LIMIT TIP" reminding the model to scope the parent record list before fanning out. The project_notes hint cites #69 by issue number so the model knows this is a known failure mode.
+
+- **README "Rate limits" section** documents the per-integration thresholds, how to raise them in Autotask Admin (dedicated API user + Workflow Rules → API Tracking Identifier), and recommended scoping patterns.
+
 - **Ticket history audit-trail tools** (`autotask_get_ticket_history`, `autotask_search_ticket_history`). Exposes the Autotask `/TicketHistory` entity (GET-only) so callers can answer "when did this ticket transition from status X to status Y", "who changed the priority", etc. `search` requires a `ticketId` (Autotask does not support unscoped history queries) and fails fast with a friendly error before any network round-trip if it's missing. Surfaced via the `tickets` category bundle.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -609,6 +609,36 @@ npm test -- tests/autotask-service.test.ts
 - `simple`: Human-readable console output
 - `json`: Structured JSON output (recommended for production)
 
+## Rate Limits
+
+Autotask enforces per-integration-code API thresholds on a rolling 1-hour window:
+
+- **~10,000 req/hr (soft)** — warning email, sporadic `HTTP 429` responses
+- **~20,000 req/hr (hard)** — sustained `HTTP 429` until the window rolls
+
+LLM-driven workflows fan out easily — "status report on all open projects with notes" can issue hundreds of requests across a few minutes. The server tries to make this safer:
+
+- **429 responses are surfaced as structured errors.** Tool results carry `error_type: "rate_limited"` and a `retry_after_seconds` field parsed from Autotask's `Retry-After` header. The error message explicitly tells the LLM **not to retry** and to ask the user to scope the query — this prevents repeated retries from extending the cooldown.
+- **Fan-out tool descriptions include rate-limit tips.** Tools that are commonly looped over (`autotask_search_ticket_notes`, `autotask_search_project_notes`, `autotask_search_company_notes`, `autotask_search_time_entries`, `autotask_search_ticket_attachments`) include a hint reminding the LLM to scope the parent record list before iterating.
+
+### Raising the limit
+
+Per-integration thresholds can be increased in Autotask:
+
+1. Autotask Admin → **Resources/Users (HR) → Resources**
+2. Edit the dedicated API user → **Workflow Rules → API Tracking Identifier**
+3. Adjust the threshold for the integration code your MCP server uses
+
+This is the right answer when a single integration code is shared between Claude/Copilot/etc. and other tooling. For LLM-heavy workloads, dedicate a separate API user (and integration code) so a fan-out from one client doesn't starve others.
+
+### Patterns that help
+
+- **Always scope by date range** when searching notes, time entries, attachments. Even a 30-day window can drop call count by an order of magnitude.
+- **Cache parent lookups.** If you're iterating over 100 tickets, fetch the ticket list once and reuse it across follow-up queries; don't re-search per child.
+- **Use `autotask_get_field_info`** to discover picklist values once per session rather than refetching them per call.
+
+If you're seeing threshold warnings from Autotask but the server seems fine, the LLM driver is probably issuing fan-out patterns. Tighten the prompt to scope before iterating.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -1100,7 +1100,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_search_ticket_notes',
-    description: 'Search for notes on a specific ticket',
+    description: 'Search for notes on a specific ticket. Iterating across many tickets trips Autotask\'s per-integration API threshold — scope the parent list first.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1270,7 +1270,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_search_project_notes',
-    description: 'Search for notes on a specific project',
+    description: 'Search for notes on a specific project. Fan-out across many projects trips Autotask\'s API threshold (see issue #69) — scope the parent list (status, company, date range) first.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1344,7 +1344,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_search_company_notes',
-    description: 'Search for notes on a specific company',
+    description: 'Search for notes on a specific company. Iterating across many companies trips Autotask\'s API threshold — scope the parent list first.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1420,7 +1420,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   },
   {
     name: 'autotask_search_ticket_attachments',
-    description: 'Search for attachments on a specific ticket',
+    description: 'Search for attachments on a specific ticket. Each parent triggers a separate query — scope the parent ticket list before iterating.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -2484,7 +2484,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   // Time Entries search tool
   {
     name: 'autotask_search_time_entries',
-    description: 'Search for time entries in Autotask. Returns 25 results per page by default. Time entries can be filtered by resource, ticket, project, task, date range, or approval status. Use approvalStatus="unapproved" to find entries not yet posted.',
+    description: 'Search for time entries in Autotask. Returns 25 results per page by default. Time entries can be filtered by resource, ticket, project, task, date range, or approval status. Use approvalStatus="unapproved" to find entries not yet posted. Common fan-out target — scope by date range first to avoid Autotask\'s API threshold.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -3,6 +3,7 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { AutotaskService } from '../services/autotask.service.js';
+import { AutotaskRateLimitError } from '../services/autotask-http.js';
 import { PicklistCache, PicklistValue } from '../services/picklist.cache.js';
 import { Logger } from '../utils/logger.js';
 import { formatCompactResponse, detectEntityType, COMPACT_SEARCH_TOOLS } from '../utils/response.formatter.js';
@@ -1457,10 +1458,7 @@ export class AutotaskToolHandler {
       const notFoundMsg = this.buildNotFoundMessage(name, args, result);
       if (notFoundMsg) {
         this.logger.debug(`Not-found result for ${name}: ${notFoundMsg}`);
-        return {
-          content: [{ type: 'text', text: JSON.stringify({ error: notFoundMsg, tool: name }) }],
-          isError: true,
-        };
+        return errorToolResult({ error: notFoundMsg, tool: name });
       }
 
       // Format and enhance response
@@ -1493,10 +1491,37 @@ export class AutotaskToolHandler {
 
     } catch (error) {
       this.logger.error(`Tool execution failed for ${name}:`, error);
-      return {
-        content: [{ type: 'text', text: JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error', tool: name }) }],
-        isError: true
-      };
+      // Surface rate-limit errors with a typed envelope so LLM clients can
+      // distinguish them from generic failures and stop retrying. Issue #91.
+      if (error instanceof AutotaskRateLimitError) {
+        return errorToolResult({
+          error_type: 'rate_limited',
+          error: error.message,
+          retry_after_seconds: error.retryAfterSeconds,
+          tool: name,
+          // Belt-and-suspenders for LLM clients that don't parse error_type.
+          instruction: 'Do not retry this call. Ask the user to narrow the query (e.g. filter by date range, company, or ticket ID) before issuing another Autotask request.',
+        });
+      }
+      return errorToolResult({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        tool: name,
+      });
     }
   }
-} 
+}
+
+/**
+ * Build a tool-result envelope for an error. Three call sites in callTool()
+ * had assembled this shape inline; this helper keeps the JSON envelope
+ * consistent so future error fields don't drift between paths.
+ */
+function errorToolResult(payload: Record<string, unknown>): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    isError: true,
+  };
+}

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -34,6 +34,49 @@ interface QueryResponse<T> {
 
 const RAW_REQUEST_METHODS = ['GET', 'POST', 'PATCH', 'DELETE'] as const;
 
+/**
+ * Thrown when Autotask returns 429 (per-integration API threshold exceeded).
+ * Carries `retryAfterSeconds` parsed from the `Retry-After` header (RFC 7231
+ * — either an integer seconds value or an HTTP-date) so callers can back off
+ * accurately. Tool handlers convert this into a structured `error_type:
+ * "rate_limited"` tool result so LLM-driven workflows stop hammering the
+ * same path. Issue #69 (faspina) — \"status report for all open projects
+ * with notes\" fan-out tripped the threshold; the model couldn't tell what
+ * happened from the generic HTTP error.
+ *
+ * Autotask thresholds (per integration code, per hour):
+ *   - ~10k req/hr soft (warning email, sporadic 429s)
+ *   - ~20k req/hr hard (sustained 429s until the window rolls)
+ */
+export class AutotaskRateLimitError extends Error {
+  readonly status = 429;
+  readonly retryAfterSeconds: number;
+
+  constructor(message: string, retryAfterSeconds: number) {
+    super(message);
+    this.name = 'AutotaskRateLimitError';
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+// Default backoff when Autotask doesn't send a parseable Retry-After header.
+// One minute is conservative: their thresholds reset on a rolling hour window,
+// so waiting longer than a minute is rarely useful, and waiting less risks
+// re-tripping while still over.
+const DEFAULT_RETRY_AFTER_SECONDS = 60;
+
+function parseRetryAfter(headerValue: string | null): number {
+  if (!headerValue) return DEFAULT_RETRY_AFTER_SECONDS;
+  // RFC 7231: either an integer count of seconds, or an HTTP-date.
+  const asInt = Number.parseInt(headerValue, 10);
+  if (Number.isFinite(asInt) && asInt >= 0) return asInt;
+  const asDate = Date.parse(headerValue);
+  if (Number.isFinite(asDate)) {
+    return Math.max(0, Math.ceil((asDate - Date.now()) / 1000));
+  }
+  return DEFAULT_RETRY_AFTER_SECONDS;
+}
+
 function assertSafeRelativePath(path: string): void {
   if (typeof path !== 'string' || path.length === 0) {
     throw new Error('Autotask rawRequest: path must be a non-empty string');
@@ -128,6 +171,19 @@ export class AutotaskHttpClient {
         }
       } catch {
         /* fall through with raw text */
+      }
+      if (response.status === 429) {
+        const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+        // Single-line message that LLMs will read verbatim — instruct against
+        // retry, surface the wait, point at the underlying issue. The structured
+        // `retryAfterSeconds` field lets handlers do programmatic things too.
+        throw new AutotaskRateLimitError(
+          `Autotask API threshold exceeded (HTTP 429). Do NOT retry this call automatically — ` +
+          `the next ${retryAfter}s will likely hit 429 again, and repeated retries can extend the ` +
+          `cooldown. Ask the user to scope the query (e.g. narrow date range, filter by company/ticket ID) ` +
+          `or wait ${retryAfter}s before trying again. Detail: ${detail}`,
+          retryAfter,
+        );
       }
       throw new Error(`Autotask ${method} ${path} failed: HTTP ${response.status}: ${detail}`);
     }

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,141 @@
+// Tests for Autotask 429/threshold handling (#69, #91).
+//
+// Covers two layers:
+//   1. AutotaskHttpClient.request maps HTTP 429 to a typed
+//      AutotaskRateLimitError with retryAfterSeconds parsed from the
+//      Retry-After header.
+//   2. AutotaskToolHandler.callTool converts that typed error into a
+//      structured tool-result envelope (error_type: "rate_limited") so
+//      LLM clients can stop retrying.
+
+import { AutotaskService } from '../src/services/autotask.service';
+import { AutotaskRateLimitError } from '../src/services/autotask-http';
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+
+const mockLogger = new Logger('error');
+const configWithUrl: McpServerConfig = {
+  name: 'test-server',
+  version: '1.0.0',
+  autotask: {
+    username: 'test-username',
+    secret: 'test-secret',
+    integrationCode: 'test-integration-code',
+    apiUrl: 'https://example.autotask.net/atservicesrest/',
+  },
+};
+
+// Build a Response-like object that includes headers (the production helper
+// in autotask-service.test.ts doesn't support headers, hence this local copy).
+function responseWith(status: number, body: any, headers: Record<string, string> = {}): Response {
+  const headerMap = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+    },
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('Rate limit handling (#69, #91)', () => {
+  let fetchSpy: jest.SpiedFunction<typeof fetch>;
+
+  afterEach(() => {
+    if (fetchSpy) fetchSpy.mockRestore();
+  });
+
+  describe('AutotaskHttpClient → AutotaskRateLimitError', () => {
+    test('throws typed error with parsed Retry-After (integer seconds)', async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(responseWith(429, { errors: ['IntegrationVendor exceeded the API threshold'] }, {
+          'Retry-After': '180',
+        }));
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      // Single call — capture the thrown error to inspect both its type and
+      // its `retryAfterSeconds` field. Previous double-call hit the fetch
+      // mock twice for no reason.
+      const err = await service.searchTickets({}).catch((e) => e);
+      expect(err).toBeInstanceOf(AutotaskRateLimitError);
+      const rateErr = err as AutotaskRateLimitError;
+      expect(rateErr.status).toBe(429);
+      expect(rateErr.retryAfterSeconds).toBe(180);
+      expect(rateErr.message).toContain('Do NOT retry');
+      expect(rateErr.message).toContain('IntegrationVendor exceeded');
+    });
+
+    test('falls back to default 60s when Retry-After is missing', async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(responseWith(429, { errors: ['Threshold exceeded'] }));
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      try {
+        await service.searchTickets({});
+        fail('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(AutotaskRateLimitError);
+        expect((err as AutotaskRateLimitError).retryAfterSeconds).toBe(60);
+      }
+    });
+
+    test('falls back to default when Retry-After is unparseable garbage', async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(responseWith(429, { errors: ['nope'] }, {
+          'Retry-After': 'sometime-tomorrow',
+        }));
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      try {
+        await service.searchTickets({});
+        fail('expected throw');
+      } catch (err) {
+        expect((err as AutotaskRateLimitError).retryAfterSeconds).toBe(60);
+      }
+    });
+
+    test('non-429 errors stay as generic Error (no false-positive rate-limit signal)', async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(responseWith(500, { errors: ['Boom'] }));
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      try {
+        await service.searchTickets({});
+        fail('expected throw');
+      } catch (err) {
+        expect(err).not.toBeInstanceOf(AutotaskRateLimitError);
+        expect((err as Error).message).toContain('HTTP 500');
+      }
+    });
+  });
+
+  describe('AutotaskToolHandler → structured rate_limited tool result', () => {
+    test('wraps AutotaskRateLimitError as error_type: rate_limited with retry_after_seconds', async () => {
+      fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(responseWith(429, { errors: ['threshold'] }, {
+          'Retry-After': '120',
+        }));
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const handler = new AutotaskToolHandler(service, mockLogger);
+
+      const result = await handler.callTool('autotask_search_tickets', { searchTerm: 'foo' });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as any).text as string;
+      const parsed = JSON.parse(text);
+      expect(parsed.error_type).toBe('rate_limited');
+      expect(parsed.retry_after_seconds).toBe(120);
+      expect(parsed.tool).toBe('autotask_search_tickets');
+      expect(parsed.instruction).toMatch(/Do not retry/);
+    });
+  });
+});


### PR DESCRIPTION
Closes #69 (faspina), closes #91 (asachs01).

LLM-driven workflows fan out easily — a \"status report on all open projects with notes\" can issue hundreds of requests. Autotask's per-integration API thresholds (~10k req/hr soft, ~20k hard) trip silently, the user sees disconnects and threshold-exceeded emails, and the model keeps retrying the same expensive path because the HTTP 429 came back as a generic \`Error\` indistinguishable from a 500.

@faspina's #69 reproduces this exactly: \"project status report including notes on all open projects.\"

## Fix

| Layer | Change |
|---|---|
| \`src/services/autotask-http.ts\` | New \`AutotaskRateLimitError\` thrown specifically on HTTP 429. Carries \`retryAfterSeconds\` parsed from \`Retry-After\` header (RFC 7231 — integer seconds or HTTP-date), falls back to 60s default. Non-429 errors stay as generic \`Error\` to avoid false-positive rate-limit signals. |
| \`src/handlers/tool.handler.ts\` | \`callTool\` recognizes the typed error and returns a structured envelope: \`{ error_type: \"rate_limited\", retry_after_seconds, error, instruction, tool }\`. The \`instruction\` field is belt-and-suspenders for LLM clients that don't parse \`error_type\` programmatically. Also extracted an \`errorToolResult()\` helper since the same envelope shape was being built inline at three sites. |
| \`src/handlers/tool.definitions.ts\` | 5 fan-out tools (\`search_*_notes\`, \`search_time_entries\`, \`search_ticket_attachments\`) get a one-line scoping tip in their descriptions. Tight — the per-call instruction in the 429 envelope is the real lever; description hints are a pre-trip nudge. |
| \`README.md\` | New \"Rate limits\" section: thresholds, how to raise them in Autotask Admin, scoping patterns. |
| \`tests/rate-limit.test.ts\` | 5 tests: Retry-After parsing (int / missing / garbage), non-429 staying as generic, end-to-end structured envelope through \`callTool\`. |

## Example response

\`\`\`json
{
  \"error_type\": \"rate_limited\",
  \"retry_after_seconds\": 180,
  \"tool\": \"autotask_search_tickets\",
  \"instruction\": \"Do not retry this call. Ask the user to narrow the query (e.g. filter by date range, company, or ticket ID) before issuing another Autotask request.\",
  \"error\": \"Autotask API threshold exceeded (HTTP 429). Do NOT retry...\"
}
\`\`\`

## Code review notes (after /simplify pass)

- **Extracted \`errorToolResult()\` helper** in \`tool.handler.ts\` — three call sites in one function had been building the same envelope inline.
- **Trimmed tool-description hints HARD** — original drafts were ~75 tokens each (5 tools × ~75 = ~280 token cost on every \`tools/list\` response). Cut each to ~15 words. The error envelope's \`instruction\` field handles post-trip behavior; descriptions just need one pre-trip nudge.
- **Fixed test 1's double mock-call** — was calling \`searchTickets\` twice (once via \`rejects.toBeInstanceOf\`, once via \`try/catch\`). Collapsed to single \`.catch(e => e)\`.

## Acceptance (from #91)

- [x] Threshold/429 errors come back as a clear tool error, not an unhandled disconnect
- [x] Fan-out tools warn before iterating across many records (via tool descriptions; LLM-readable hint)
- [x] README has a \"Rate limits\" section

## Deferred (per @asachs01's spec but not blocking)

- Hard refuse on projected high-volume calls (would require schema changes per tool — \`confirm_high_volume: true\` arg). The soft hint approach lets the model still do the right call when scoped, just nudges it to ask first.

## Verification

- [x] \`npm run build\` clean
- [x] \`npm test\` — **104/104** (up from 99; 5 new)
- [x] \`npm run lint\` — 0 errors