### PR TITLE
ci: bump mcp-assert reusable workflow to packages:read fix

### DIFF
--- a/.github/workflows/mcp-assert.yml
+++ b/.github/workflows/mcp-assert.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   assert:
-    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@03d64fcdcce377f8a8d86ef9b66b125dc8156149  # main
+    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@17b5a183964aa163d82e9f7092186086e97bc70e  # main
     with:
       entry: dist/entry.js
       canary-tool: autotask_test_connection


### PR DESCRIPTION
Bumps the pinned `mcp-assert.yml` reusable-workflow ref from `03d64fcdcce377f8a8d86ef9b66b125dc8156149` to `17b5a183964aa163d82e9f7092186086e97bc70e` (wyre-technology/.github#15). That commit adds `permissions: packages:read` + npm scope so the `assert` job's `npm ci` no longer 401s on `@wyre-technology/*` GitHub Packages.