### PR TITLE
fix(ci): gate docker/deploy on actual release to stop :latest tag regression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,13 @@ jobs:
     # triggering commit. The MCP Registry verifies tag-pinned images, so
     # tag/version drift breaks publishing.
     needs: [release]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Gate on an actual semantic-release. On a non-release push to main,
+    # package.json still holds the previous version (it is never committed back
+    # without @semantic-release/git), so this job would rebuild and re-push
+    # :latest tagged with that stale version, clobbering the correctly-tagged
+    # :latest from the last real release. Skipping docker cascades to
+    # security/deploy/registry (skipped dependency).
+    if: needs.release.outputs.released == 'true'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Problem
A non-release push to `main` rebuilt and re-pushed `:latest` tagged with the **stale** `package.json` version (package.json is never committed back, since `.releaserc.json` has no `@semantic-release/git` plugin). That clobbered the correctly-versioned `:latest` from the last real release — which is exactly the vendor-image drift the nightly audit flagged.

## Fix
Gate the `docker` job on `needs.release.outputs.released == 'true'`. Skipping docker cascades to deploy/registry (skipped dependency), so non-release pushes can no longer regress `:latest`.

## Effect of merging
This `fix(ci):` commit triggers a patch release, which republishes a correctly-versioned `:latest` and digest-pins it to prod via the deploy job — resolving the current drift for this vendor.

Part of the vendor-image-drift remediation.