### PR TITLE
fix(ci): repair MCPB pack/upload after package scope rename

### DIFF
--- a/scripts/pack-mcpb.js
+++ b/scripts/pack-mcpb.js
@@ -87,7 +87,10 @@ try {
 
   // 7. Pack the bundle
   console.log('\n=== Packing MCPB bundle ===');
-  const bundlePath = join(ROOT, `${pkg.name}.mcpb`);
+  // Strip the npm scope (e.g. @wyre-technology/) so the bundle is written to a
+  // flat file (autotask-mcp.mcpb) instead of a scoped path that breaks upload.
+  const bundleName = pkg.name.replace(/^@.*\//, '');
+  const bundlePath = join(ROOT, `${bundleName}.mcpb`);
   run(`npx mcpb pack "${STAGING}" "${bundlePath}"`, { cwd: ROOT });
 
   // 8. Cleanup
@@ -97,7 +100,7 @@ try {
   console.log('\n=== Done! ===');
   if (existsSync(bundlePath)) {
     const stats = require('fs').statSync(bundlePath);
-    console.log(`Bundle: ${pkg.name}.mcpb (${(stats.size / 1024 / 1024).toFixed(1)}MB)`);
+    console.log(`Bundle: ${bundleName}.mcpb (${(stats.size / 1024 / 1024).toFixed(1)}MB)`);
   }
 } catch (error) {
   console.error('Pack failed:', error.message);


### PR DESCRIPTION
## Problem

The Release job failed at the **Pack and upload MCPB bundle** step with:

```
no matches found for `autotask-mcp.mcpb`
Process completed with exit code 1
```

The npm package was renamed to the scoped name `@wyre-technology/autotask-mcp`. `scripts/pack-mcpb.js` derived the bundle filename directly from `pkg.name`, so it wrote the bundle to a **scoped path** `@wyre-technology/autotask-mcp.mcpb` (with a directory component). The release workflow uploads the flat filename `autotask-mcp.mcpb`, which no longer existed, so `gh release upload` failed and turned the whole Release run red (blocking downstream Docker/Deploy).

## Fix

Strip the npm scope when deriving the bundle filename, matching the working `ninjaone-mcp` pack script:

```js
const bundleName = pkg.name.replace(/^@.*\//, '');
const bundlePath = join(ROOT, `${bundleName}.mcpb`);
```

npm v2.28.0 already published successfully; this only repairs the MCPB upload + downstream jobs.