### PR TITLE
fix(autotask): clamp per-page MaxRecords to Autotask API limit (500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@
 
 ### Fixed
 
+- **`listAllCompanies` and other `query()` callers now clamp the per-page `MaxRecords` body param to the Autotask API limit (500).** `AutotaskHttpClient.query()` previously passed the caller's `opts.maxRecords` value directly as the per-page `MaxRecords` field in the request body. `MappingService.refreshCompanyCache()` calls `listAllCompanies(20_000)`, which produced `MaxRecords: 20000` in the request — Autotask responds with HTTP 500 "maxCountOfRecordsToReturn must be between 1 and 500". The cache pre-warm worked fine on the legacy static-singleton MappingService because it ran exactly once per process and the failure was silently absorbed into an empty cache; once the cache was made per-request the same call ran on every request and surfaced the API error on every call.
+  - Introduced an exported `AUTOTASK_MAX_PAGE_SIZE = 500` constant in `src/services/autotask-http.ts`.
+  - `query()` now treats `opts.maxRecords` as the **total cap** (how many rows to collect across the whole pagination walk) and derives the **per-page size** as `min(totalCap, AUTOTASK_MAX_PAGE_SIZE)`. The cursor walk continues to follow `pageDetails.nextPageUrl` until the total cap is reached.
+  - `childQuery()` clamps its per-page `MaxRecords` to `AUTOTASK_MAX_PAGE_SIZE` for the same reason. `childQuery` does not walk `nextPageUrl`, so only the clamp matters there.
+  - 2 new regression tests in `tests/autotask-service.test.ts` under `Per-page MaxRecords clamping`:
+    - `listAllCompanies` with the default 20_000 cap captures the actual `MaxRecords` value sent and asserts it is `<= 500`, while still returning all 700 records from a multi-page tenant.
+    - `query()` honors a small caller cap (25) by sending exactly `MaxRecords: 25` — small queries don't pay the full 500-row page cost.
+
 - **Per-instance `MappingService` for proper tenant isolation in gateway mode.** Aligns the `MappingService` lifecycle with the per-request `AutotaskToolHandler` introduced in the worker refactor so each request gets its own mapping cache scoped to the request's credentials.
   - Removed `static initPromise` and `private constructor`. Replaced the static `getInstance()` factory with a per-call `MappingService.create(autotaskService, logger, options)` that constructs a fresh instance bound to the supplied `AutotaskService` and awaits its cache initialization. Concurrent inits on the same instance still coalesce via a new per-instance `initPromise`.
   - `AutotaskToolHandler.getMappingService()` now calls `MappingService.create(...)`. Because `AutotaskToolHandler` is already constructed per-request in gateway mode (via `McpServer.buildPerRequestHandlers`, added in the worker refactor), each request now ends up with its own isolated `MappingService`.

--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -35,6 +35,16 @@ interface QueryResponse<T> {
 const RAW_REQUEST_METHODS = ['GET', 'POST', 'PATCH', 'DELETE'] as const;
 
 /**
+ * Maximum value Autotask accepts for the per-page `MaxRecords` body param on
+ * `/query` endpoints. Anything outside [1, AUTOTASK_MAX_PAGE_SIZE] returns
+ * HTTP 500 with the body "maxCountOfRecordsToReturn must be between 1 and 500".
+ * This is the per-page page-size limit, NOT a cap on total rows the caller
+ * can retrieve — multi-page walks via `pageDetails.nextPageUrl` aggregate
+ * across pages until the caller's `opts.maxRecords` total cap is reached.
+ */
+export const AUTOTASK_MAX_PAGE_SIZE = 500;
+
+/**
  * Thrown when Autotask returns 429 (per-integration API threshold exceeded).
  * Carries `retryAfterSeconds` parsed from the `Retry-After` header (RFC 7231
  * — either an integer seconds value or an HTTP-date) so callers can back off
@@ -253,9 +263,15 @@ export class AutotaskHttpClient {
   /**
    * POST /{Entity}/query — handles pagination transparently via nextPageUrl.
    *
-   * `maxRecords` caps the server-side page size (Autotask calls this MaxRecords).
-   * This method will keep following pageDetails.nextPageUrl until exhausted OR
-   * until the collected length reaches `maxRecords` (whichever is smaller).
+   * `opts.maxRecords` is the TOTAL CAP — the caller's "stop after this many
+   * rows" budget across the whole pagination walk. The PER-PAGE size sent in
+   * the request body (`MaxRecords`) is a separate concept: Autotask rejects
+   * any value outside [1, AUTOTASK_MAX_PAGE_SIZE] with
+   * HTTP 500 "maxCountOfRecordsToReturn must be between 1 and 500". The
+   * per-page size is therefore clamped to `min(maxRecords, AUTOTASK_MAX_PAGE_SIZE)`
+   * regardless of how large the caller's total cap is, and the walk keeps
+   * following `pageDetails.nextPageUrl` until exhausted or `items.length`
+   * reaches the total cap.
    *
    * Pass an empty filter array to request "all rows" — the caller is expected
    * to supply the Autotask-required `{op:'gte', field:'id', value:0}` sentinel
@@ -266,10 +282,11 @@ export class AutotaskHttpClient {
     filter: QueryFilter[],
     opts: QueryOptions = {}
   ): Promise<T[]> {
-    const maxRecords = opts.maxRecords ?? 500;
+    const totalCap = opts.maxRecords ?? AUTOTASK_MAX_PAGE_SIZE;
+    const pageSize = Math.min(totalCap, AUTOTASK_MAX_PAGE_SIZE);
     const body: Record<string, any> = {
       filter,
-      MaxRecords: maxRecords,
+      MaxRecords: pageSize,
     };
     if (opts.includeFields && opts.includeFields.length > 0) {
       body.IncludeFields = opts.includeFields;
@@ -281,13 +298,13 @@ export class AutotaskHttpClient {
 
     while (
       resp?.pageDetails?.nextPageUrl &&
-      items.length < maxRecords
+      items.length < totalCap
     ) {
       resp = await this.request<QueryResponse<T>>('GET', resp.pageDetails.nextPageUrl);
       if (resp?.items) items.push(...resp.items);
     }
 
-    return items.slice(0, maxRecords);
+    return items.slice(0, totalCap);
   }
 
   /**
@@ -379,9 +396,13 @@ export class AutotaskHttpClient {
     filter: QueryFilter[],
     opts: QueryOptions = {}
   ): Promise<T[]> {
+    // Per-page size sent to Autotask must respect AUTOTASK_MAX_PAGE_SIZE.
+    // childQuery does not walk nextPageUrl, so the request gets at most a
+    // single page; clamping is the only thing that matters here.
+    const pageSize = Math.min(opts.maxRecords ?? AUTOTASK_MAX_PAGE_SIZE, AUTOTASK_MAX_PAGE_SIZE);
     const body: Record<string, any> = {
       filter,
-      MaxRecords: opts.maxRecords ?? 500,
+      MaxRecords: pageSize,
     };
     if (opts.includeFields && opts.includeFields.length > 0) {
       body.IncludeFields = opts.includeFields;

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -726,6 +726,72 @@ describe('AutotaskService', () => {
       warnSpy.mockRestore();
     });
 
+    // ---- Per-page MaxRecords clamping (regression: listAllCompanies HTTP 500) ----
+
+    test('listAllCompanies clamps per-page MaxRecords to <=500 even when total cap is large', async () => {
+      // Without clamping, `listAllCompanies()` (default cap 20_000) would
+      // send `MaxRecords: 20000` in the request body, which Autotask rejects
+      // with HTTP 500 "maxCountOfRecordsToReturn must be between 1 and 500".
+      // The fix is to separate the caller's TOTAL cap (used as a stop
+      // condition while walking pageDetails.nextPageUrl) from the PER-PAGE
+      // size sent to the API.
+      const capturedMaxRecords: number[] = [];
+      const buildBatch = (start: number, count: number) =>
+        Array.from({ length: count }, (_, i) => ({
+          id: start + i,
+          companyName: `Company ${start + i}`,
+        }));
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+        const url = typeof input === 'string' ? input : (input as URL).toString();
+        const method = (init?.method || 'GET').toUpperCase();
+        if (method === 'POST' && url === `${BASE}/Companies/query`) {
+          const body = JSON.parse(init!.body as string);
+          capturedMaxRecords.push(body.MaxRecords);
+          return jsonResponse({
+            items: buildBatch(1, 500),
+            pageDetails: { nextPageUrl: `${BASE}/Companies/query?page=2` },
+          });
+        }
+        if (method === 'GET' && url.includes('Companies/query?page=2')) {
+          return jsonResponse({
+            items: buildBatch(501, 200),
+            pageDetails: { nextPageUrl: null },
+          });
+        }
+        throw new Error(`unexpected fetch ${method} ${url}`);
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const all = await service.listAllCompanies(); // default cap 20_000
+
+      // The body of the initial POST MUST clamp to <=500 even though the
+      // caller wanted up to 20_000 total. The cursor walk handles the rest.
+      expect(capturedMaxRecords).toHaveLength(1);
+      expect(capturedMaxRecords[0]).toBeLessThanOrEqual(500);
+      expect(all).toHaveLength(700);
+    });
+
+    test('query() honors caller total cap smaller than per-page clamp', async () => {
+      // When the caller asks for fewer rows than the per-page max (e.g. 25),
+      // the per-page MaxRecords must equal the caller's small ask — not 500.
+      // Keeps targeted-fetch costs low for small queries.
+      let capturedMaxRecords: number | undefined;
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+        const body = JSON.parse(init!.body as string);
+        capturedMaxRecords = body.MaxRecords;
+        return jsonResponse({
+          items: Array.from({ length: 25 }, (_, i) => ({ id: i + 1, companyName: `Co ${i + 1}` })),
+          pageDetails: { nextPageUrl: null },
+        });
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const result = await service.searchCompanies({ page: 1, pageSize: 25 } as any);
+
+      expect(result).toHaveLength(25);
+      expect(capturedMaxRecords).toBe(25);
+    });
+
     // ---- search* filter translation (regression: issues #104, #105) ----
     //
     // Four search methods (Contracts, ConfigurationItems, Invoices, Tasks)


### PR DESCRIPTION
## Summary

`AutotaskHttpClient.query()` passed `opts.maxRecords` directly as the per-page `MaxRecords` body param. `MappingService.refreshCompanyCache()` calls `listAllCompanies(20_000)`, so requests carried `MaxRecords: 20000` — Autotask rejects values outside `[1, 500]` with `HTTP 500 "maxCountOfRecordsToReturn must be between 1 and 500"`.

The bug was masked by the legacy static-singleton `MappingService`: `initializeCache` ran exactly once per process and the failure was silently absorbed into an empty cache. The per-instance `MappingService` ([#131](https://github.com/wyre-technology/autotask-mcp/pull/131)) re-runs `initializeCache` on every request, surfacing the API error on every call. Production was held safe by toggling `LAZY_LOADING=true` while this fix lands.

## Root cause

`opts.maxRecords` was being used for two different things at once:

| Concept | Where it's used | Autotask constraint |
|---|---|---|
| Per-page page size | `body.MaxRecords` in each `/query` POST | Must be in `[1, 500]` |
| Total cap | Stop condition while walking `pageDetails.nextPageUrl` + final `slice` | No upper bound from Autotask; caller's "budget" |

These were the same variable, so any caller asking for more than 500 total rows sent a per-page value Autotask rejects.

## Fix

`src/services/autotask-http.ts`:

- New exported constant `AUTOTASK_MAX_PAGE_SIZE = 500` (named for the API constraint, with the exact error-string in the docstring so future grepping finds it).
- `query()` now treats `opts.maxRecords` as the **total cap** and derives the **per-page size** as `Math.min(totalCap, AUTOTASK_MAX_PAGE_SIZE)`. The cursor walk over `pageDetails.nextPageUrl` continues until `items.length >= totalCap` (unchanged).
- `childQuery()` clamps its per-page `MaxRecords` to `AUTOTASK_MAX_PAGE_SIZE` for symmetry. `childQuery` does not walk `nextPageUrl`, so only the clamp matters there.

## Tests

`tests/autotask-service.test.ts` — new `Per-page MaxRecords clamping` block:

- `listAllCompanies clamps per-page MaxRecords to <=500 even when total cap is large` — calls `listAllCompanies()` with the default 20_000 cap, captures the actual `MaxRecords` value sent, asserts it is `<= 500`, and verifies all 700 records are still returned from a 2-page mocked tenant. This test FAILS without the fix.
- `query() honors caller total cap smaller than per-page clamp` — calls `searchCompanies({ page:1, pageSize:25 })`, captures the body, asserts `MaxRecords === 25`. Pins the no-regression case for small-budget callers.

Full suite: **122/122 passing** (up from 120/120).

## Diff size

`+103 / -8` LOC across 3 files (1 source, 1 test, 1 CHANGELOG entry).

## Post-merge

Once this ships and is L1–L5 verified on the gateway, `LAZY_LOADING=true` can be reverted on prod — the eager-warm `MappingService` cache is restored without the regression that prompted the workaround. **Do not revert `LAZY_LOADING=true` before this PR's image is verified live.**

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 122/122
- [ ] Reviewer: confirm `AUTOTASK_MAX_PAGE_SIZE` is the only literal `500` controlling per-page size after the change (the constant carries the API error-string in its docstring for grep discoverability)
- [ ] Post-merge: forge to drive staging deploy, hit `/mcp` with `LAZY_LOADING` unset, verify `MappingService.initializeCache` succeeds end-to-end for a multi-page tenant
- [ ] Then: revert `LAZY_LOADING=true` env on prod gateway

## Related

- [autotask-mcp #131](https://github.com/wyre-technology/autotask-mcp/pull/131) — per-instance MappingService change that surfaced this latent pagination bug.