### PR TITLE
build(deps-dev): adopt TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,11 +32,11 @@
         "semantic-release": "^25.0.0",
         "ts-jest": "^29.4.11",
         "tsx": "^4.22.4",
-        "typescript": "^5.3.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -15280,9 +15280,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "semantic-release": "^25.0.0",
     "ts-jest": "^29.4.11",
     "tsx": "^4.22.4",
-    "typescript": "^5.3.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020", "ES2022.Error"],
+    "lib": [
+      "ES2020",
+      "ES2022.Error"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -20,7 +23,11 @@
     "noUnusedParameters": true,
     "exactOptionalPropertyTypes": true,
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": [
+      "node"
+    ],
+    "ignoreDeprecations": "6.0"
   },
   "include": [
     "src/**/*"
@@ -31,4 +38,4 @@
     "**/*.test.ts",
     "**/*.spec.ts"
   ]
-} 
+}


### PR DESCRIPTION
Fleet TS6 migration (tracker: wyre-technology/mcp-gateway#221). Applied via the ts6-fleet-migration codemod: `types:["node"]` + `ignoreDeprecations:"6.0"` as needed, `typescript ^6.0.3`. Local typecheck (`build`) passed; CI runs full build/test.