### PR TITLE
fix(enrich): bound search-result name enrichment concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ MCP_HTTP_HOST=0.0.0.0        # HTTP transport bind address
 LOG_LEVEL=info          # error, warn, info, debug
 LOG_FORMAT=simple       # simple, json
 
+# Search-result name enrichment
+# Max concurrent Autotask API calls used to resolve company/resource names on
+# search results. Kept low to stay under Autotask's per-integration
+# concurrent-thread limit (raising it risks HTTP 429 "thread threshold").
+AUTOTASK_ENHANCE_CONCURRENCY=3
+
 # Environment
 NODE_ENV=production
 ```
@@ -602,6 +608,7 @@ npm test -- tests/autotask-service.test.ts
 | `MCP_HTTP_HOST` | ❌ | `0.0.0.0` | HTTP transport bind address |
 | `LOG_LEVEL` | ❌ | `info` | Logging level |
 | `LOG_FORMAT` | ❌ | `simple` | Log output format |
+| `AUTOTASK_ENHANCE_CONCURRENCY` | ❌ | `3` | Max concurrent Autotask API calls used to resolve company/resource names on search results. Kept low to stay under Autotask's concurrent-thread limit. |
 | `NODE_ENV` | ❌ | `development` | Node.js environment |
 
 ### Logging Levels

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -8,7 +8,18 @@ import { PicklistCache, PicklistValue } from '../services/picklist.cache.js';
 import { Logger } from '../utils/logger.js';
 import { formatCompactResponse, detectEntityType, COMPACT_SEARCH_TOOLS } from '../utils/response.formatter.js';
 import { MappingService } from '../utils/mapping.service.js';
+import { mapWithConcurrency } from '../utils/concurrency.js';
 import { TOOL_DEFINITIONS, TOOL_CATEGORIES } from './tool.definitions.js';
+
+// Default concurrency for company/resource name enrichment. Autotask allows
+// only a handful of concurrent API threads per integration, so enrichment is
+// fanned out in small batches rather than all at once (see enhanceItems).
+const DEFAULT_ENHANCE_CONCURRENCY = 3;
+
+function resolveEnhanceConcurrency(raw: string | undefined): number {
+  const parsed = parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : DEFAULT_ENHANCE_CONCURRENCY;
+}
 
 // Fields accepted by autotask_create_ticket / autotask_update_ticket.
 // Keep this list in sync with the tool definitions in tool.definitions.ts.
@@ -77,11 +88,13 @@ export class AutotaskToolHandler {
   protected mcpServer: Server | null = null;
   private mappingService: MappingService | null = null;
   private lazyLoading: boolean;
+  private enhanceConcurrency: number;
 
   constructor(autotaskService: AutotaskService, logger: Logger, lazyLoading = false) {
     this.autotaskService = autotaskService;
     this.logger = logger;
     this.lazyLoading = lazyLoading;
+    this.enhanceConcurrency = resolveEnhanceConcurrency(process.env.AUTOTASK_ENHANCE_CONCURRENCY);
     this.picklistCache = new PicklistCache(
       logger,
       (entityType) => this.autotaskService.getFieldInfo(entityType)
@@ -107,8 +120,14 @@ export class AutotaskToolHandler {
   private async enhanceItems(items: any[]): Promise<any[]> {
     try {
       const mappingService = await this.getMappingService();
-      const enhanced = await Promise.allSettled(
-        items.map(async (item) => {
+      // Bound the fan-out: one item may trigger up to a few Autotask API
+      // calls (company + resource names), and Autotask 429s past its
+      // concurrent-thread limit. mapWithConcurrency keeps us under it so
+      // every row's names resolve instead of most of them being dropped.
+      const enhanced = await mapWithConcurrency(
+        items,
+        this.enhanceConcurrency,
+        async (item) => {
           const result = { ...item };
           if (item.companyID != null && typeof item.companyID === 'number') {
             try {
@@ -129,7 +148,7 @@ export class AutotaskToolHandler {
             } catch { /* skip */ }
           }
           return result;
-        })
+        }
       );
       return enhanced
         .filter((r): r is PromiseFulfilledResult<any> => r.status === 'fulfilled')

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,42 @@
+// Bounded-concurrency async helpers.
+//
+// Autotask enforces a per-integration concurrent-thread limit (HTTP 429
+// "API thread threshold of N threads has been exceeded"). Fanning out one
+// API call per result row with an unbounded Promise.allSettled blows that
+// limit on broad result sets, so most calls 429 and their data is lost.
+// mapWithConcurrency caps how many mappers run at once.
+
+/**
+ * Run `fn` over `items` with at most `limit` invocations in flight at once.
+ *
+ * Behaves like `Promise.allSettled(items.map(fn))` — results are returned in
+ * input order and a rejected mapper produces a `{ status: 'rejected' }` entry
+ * rather than aborting the batch — but never exceeds `limit` concurrency.
+ *
+ * @param items Items to map over.
+ * @param limit Maximum number of concurrent invocations (coerced to >= 1).
+ * @param fn Async mapper, receives the item and its index.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  const maxConcurrency = Math.max(1, Math.floor(limit) || 1);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    for (let index = nextIndex++; index < items.length; index = nextIndex++) {
+      try {
+        results[index] = { status: 'fulfilled', value: await fn(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  }
+
+  const workerCount = Math.min(maxConcurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -327,6 +327,7 @@ When AUTH_MODE=gateway, credentials are injected by the MCP Gateway:
   MCP_HTTP_HOST            - HTTP host when using http transport (default: 0.0.0.0)
   LOG_LEVEL                - Logging level: error, warn, info, debug (default: info)
   LOG_FORMAT               - Log format: simple, json (default: simple)
+  AUTOTASK_ENHANCE_CONCURRENCY - Max concurrent Autotask API calls used to resolve company/resource names on search results (default: 3). Kept low to stay under Autotask's concurrent-thread limit.
 
 Example (Local Mode):
   AUTOTASK_USERNAME=api-user@example.com

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for mapWithConcurrency.
+ * Verifies bounded concurrency, input-order results, and per-item error
+ * isolation — the properties enhanceItems relies on to stay under Autotask's
+ * concurrent-thread limit.
+ */
+
+import { mapWithConcurrency } from '../src/utils/concurrency';
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('mapWithConcurrency', () => {
+  it('returns fulfilled results in input order', async () => {
+    const results = await mapWithConcurrency([1, 2, 3, 4], 2, async (n) => n * 10);
+    expect(results).toEqual([
+      { status: 'fulfilled', value: 10 },
+      { status: 'fulfilled', value: 20 },
+      { status: 'fulfilled', value: 30 },
+      { status: 'fulfilled', value: 40 },
+    ]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+
+    await mapWithConcurrency(items, 3, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return n;
+    });
+
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it('runs at the full limit when there is enough work', async () => {
+    const gate = deferred();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 6 }, (_, i) => i);
+
+    const run = mapWithConcurrency(items, 3, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await gate.promise; // hold every started worker open
+      inFlight--;
+      return n;
+    });
+
+    // Let the initial batch start, then release.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(maxInFlight).toBe(3);
+    gate.resolve();
+    await run;
+  });
+
+  it('isolates rejections without aborting the batch', async () => {
+    const results = await mapWithConcurrency([1, 2, 3], 2, async (n) => {
+      if (n === 2) throw new Error('boom');
+      return n;
+    });
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 1 });
+    expect(results[1].status).toBe('rejected');
+    expect((results[1] as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 3 });
+  });
+
+  it('handles an empty input', async () => {
+    expect(await mapWithConcurrency([], 3, async (n) => n)).toEqual([]);
+  });
+
+  it('coerces a limit below 1 up to serial execution', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    await mapWithConcurrency([1, 2, 3], 0, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 2));
+      inFlight--;
+      return n;
+    });
+    expect(maxInFlight).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Search-result name enrichment (`enhanceItems`) resolves company/resource
names by firing **one Autotask API call per result row** through an unbounded
`Promise.allSettled`. Autotask enforces a per-integration **concurrent-thread
limit (~3)**, so a broad result set blows it: most lookups return HTTP 429
("API thread threshold of 3 threads has been exceeded"), and because the
rejections are swallowed, those rows come back with **no resolved name**.

This bounds the enrichment fan-out so it stays under the thread limit and
every row's names resolve.

## Root cause

`src/handlers/tool.handler.ts` → `enhanceItems`:

```ts
const enhanced = await Promise.allSettled(
  items.map(async (item) => { /* getCompanyName / getResourceName per item */ })
);
```

For an N-row result set with cold/lazy name caches, this issues up to N
concurrent Autotask calls at once. Past ~3 in flight, Autotask returns 429
and the swallowed failures mean the `company` / `assignedTo` fields are
silently dropped.

**Observed** (gateway mode, a 25-row `autotask_search_contracts` result):

- Only **3 of 25** company names resolved.
- **42 × HTTP 429** emitted in a 66 ms window, all from
  `enhanceItems → getCompanyName → getCompany`.

## Fix

- Add `src/utils/concurrency.ts` → `mapWithConcurrency(items, limit, fn)`: a
  bounded `Promise.allSettled` (input-order results, per-item error
  isolation, never more than `limit` in flight).
- `enhanceItems` uses it with a small default concurrency (**3**, matching
  Autotask's documented thread limit), configurable via
  `AUTOTASK_ENHANCE_CONCURRENCY`.

Enrichment now runs in small batches, stays under the thread limit, and
resolves every row — trading a little latency for complete, correct data.

## Validation (live Autotask)

Same 25-row contracts search, before vs. after:

| | Before | After (concurrency=3) |
|---|---|---|
| Company names resolved | **3 / 25** | **25 / 25** |
| HTTP 429s emitted | **42 in 66 ms** | **0** |
| Latency | ~3.6 s | ~8.4 s |

## Configuration

| Variable | Default | Description |
|---|---|---|
| `AUTOTASK_ENHANCE_CONCURRENCY` | `3` | Max concurrent Autotask API calls used to resolve company/resource names on search results. Kept low to stay under Autotask's concurrent-thread limit. |

Documented in `README.md` and `getConfigHelp()`.

## Testing

- `npm run build` ✓ · `tsc --noEmit` ✓ · `eslint src` ✓ (0 errors) ·
  `npm test` ✓ **138 passed** (incl. 6 new `mapWithConcurrency` tests:
  ordering, never-exceeds-limit, runs-at-full-limit, error isolation, empty
  input, sub-1 coercion).

## Notes

- **Distinct from #91.** That issue/PR handles the **hourly request-volume**
  cap (~10k/20k per integration code) by surfacing 429s to the model. This is
  the **concurrent-thread** limit. The two are complementary: bounding
  concurrency *prevents* a class of 429s rather than just reporting them.
- **Caching unchanged.** The company direct-get fallback is intentionally not
  cached (#68, to avoid a stale direct-get poisoning the cache). This PR does
  not touch that — it only bounds how many of those (still-uncached) lookups
  run at once, making the fallback reliable under load as #68 intended.
## Related

- #69 — a single-user reporter hitting Autotask 429/threshold errors that the
  maintainer noted "shouldn't" happen for one user. The unbounded enrichment
  fan-out described here is a mechanism that trips the **concurrent-thread**
  limit even for a single user, independent of request volume.
- #91 / #107 surfaced 429s as structured errors and addressed the **hourly
  request-volume** cap. This PR is complementary: it *prevents* a class of
  429s (concurrent-thread) rather than reporting them after the fact.
- Pairs with the cursor-pagination fix (POST on nextPageUrl): a working
  company cache turns most lookups into cache hits; this bound covers the
  remaining per-record fallbacks.
