### PR TITLE
fix(http): paginate query() with POST on nextPageUrl, not GET

### DIFF
--- a/src/services/autotask-http.ts
+++ b/src/services/autotask-http.ts
@@ -305,7 +305,12 @@ export class AutotaskHttpClient {
       resp?.pageDetails?.nextPageUrl &&
       items.length < totalCap
     ) {
-      resp = await this.request<QueryResponse<T>>('GET', resp.pageDetails.nextPageUrl);
+      // Autotask's thread-safe pagination returns nextPageUrl as
+      // `/{entity}/query/next?paging=...` and requires the SAME POST + filter
+      // body as the initial query; a GET returns HTTP 405 ("does not support
+      // http method 'GET'"), which silently truncates large result sets (e.g.
+      // the company name cache never loads past the first page).
+      resp = await this.request<QueryResponse<T>>('POST', resp.pageDetails.nextPageUrl, body);
       if (resp?.items) items.push(...resp.items);
     }
 

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -611,8 +611,9 @@ describe('AutotaskService', () => {
     test('searchCompanies honors page by slicing over http.query cursor pagination', async () => {
       // Simulate a tenant whose /Companies/query endpoint returns:
       //   - first POST  → 200 items + nextPageUrl
-      //   - second GET  → 200 items + nextPageUrl
-      //   - third GET   → 100 items, no nextPage
+      //   - second POST → 200 items + nextPageUrl
+      //   - third POST  → 100 items, no nextPage
+      // Autotask's cursor pagination requires POST on nextPageUrl (a GET 405s).
       const totalRecords = 500;
       const buildBatch = (start: number, count: number) =>
         Array.from({ length: count }, (_, i) => ({
@@ -630,14 +631,14 @@ describe('AutotaskService', () => {
             pageDetails: { nextPageUrl: `${BASE}/Companies/query?page=2` },
           });
         }
-        if (method === 'GET' && url.includes('Companies/query?page=2')) {
+        if (method === 'POST' && url.includes('Companies/query?page=2')) {
           callIndex = 2;
           return jsonResponse({
             items: buildBatch(201, 200),
             pageDetails: { nextPageUrl: `${BASE}/Companies/query?page=3` },
           });
         }
-        if (method === 'GET' && url.includes('Companies/query?page=3')) {
+        if (method === 'POST' && url.includes('Companies/query?page=3')) {
           callIndex = 3;
           return jsonResponse({
             items: buildBatch(401, 100),
@@ -675,13 +676,13 @@ describe('AutotaskService', () => {
             pageDetails: { nextPageUrl: `${BASE}/Companies/query?page=2` },
           });
         }
-        if (method === 'GET' && url.includes('Companies/query?page=2')) {
+        if (method === 'POST' && url.includes('Companies/query?page=2')) {
           return jsonResponse({
             items: buildBatch(201, 200),
             pageDetails: { nextPageUrl: `${BASE}/Companies/query?page=3` },
           });
         }
-        if (method === 'GET' && url.includes('Companies/query?page=3')) {
+        if (method === 'POST' && url.includes('Companies/query?page=3')) {
           return jsonResponse({
             items: buildBatch(401, 100),
             pageDetails: { nextPageUrl: null },
@@ -695,6 +696,38 @@ describe('AutotaskService', () => {
       expect(all).toHaveLength(500);
       expect(all[0].id).toBe(1);
       expect(all[499].id).toBe(500);
+    });
+
+    test('cursor pagination POSTs the nextPageUrl with the filter body (not GET)', async () => {
+      // Regression: Autotask returns nextPageUrl as `/query/next?paging=...`,
+      // which only accepts POST with the original filter body. A GET returns
+      // HTTP 405 and truncates results to the first page.
+      const calls: Array<{ method: string; url: string; body: any }> = [];
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+        const url = typeof input === 'string' ? input : (input as URL).toString();
+        const method = (init?.method || 'GET').toUpperCase();
+        const body = init?.body ? JSON.parse(init.body as string) : undefined;
+        calls.push({ method, url, body });
+        if (url.endsWith('/Companies/query')) {
+          return jsonResponse({
+            items: [{ id: 1, companyName: 'A' }],
+            pageDetails: { nextPageUrl: `${BASE}/Companies/query/next?paging=abc` },
+          });
+        }
+        // The next-page request — must be POST; a GET here would mean the bug.
+        if (method !== 'POST') {
+          return new Response('{"Message":"The requested resource does not support http method \'GET\'."}', { status: 405 });
+        }
+        return jsonResponse({ items: [{ id: 2, companyName: 'B' }], pageDetails: { nextPageUrl: null } });
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const all = await service.listAllCompanies();
+
+      expect(all.map(c => c.id)).toEqual([1, 2]);
+      const nextCall = calls.find(c => c.url.includes('/query/next'));
+      expect(nextCall?.method).toBe('POST');
+      expect(nextCall?.body).toHaveProperty('filter');
     });
 
     test('listAllCompanies warns and returns when maxRecords cap is hit', async () => {
@@ -752,7 +785,7 @@ describe('AutotaskService', () => {
             pageDetails: { nextPageUrl: `${BASE}/Companies/query?page=2` },
           });
         }
-        if (method === 'GET' && url.includes('Companies/query?page=2')) {
+        if (method === 'POST' && url.includes('Companies/query?page=2')) {
           return jsonResponse({
             items: buildBatch(501, 200),
             pageDetails: { nextPageUrl: null },
@@ -893,7 +926,7 @@ describe('AutotaskService', () => {
             pageDetails: { nextPageUrl: `${BASE}/Tasks/query?page=2` },
           });
         }
-        if (method === 'GET' && url.includes('Tasks/query?page=2')) {
+        if (method === 'POST' && url.includes('Tasks/query?page=2')) {
           return jsonResponse({
             items: buildBatch(26, 25),
             pageDetails: { nextPageUrl: null },


### PR DESCRIPTION
## Summary

`AutotaskHttpClient.query()` walks Autotask's cursor pagination by issuing a
**`GET`** on `pageDetails.nextPageUrl`. Autotask returns that URL as
`/{entity}/query/next?paging=...`, which only accepts **`POST`** (with the same
filter body as the initial query) — a `GET` returns **HTTP 405** ("The
requested resource does not support http method 'GET'"). Callers swallow the
error, so any result set beyond the first page (500 records) is **silently
truncated**.

The most visible impact: `MappingService`'s company-name cache pre-warm
(`listAllCompanies`) fails on any tenant with >500 companies, so the cache
never populates and every ID→name lookup falls through to a per-record
fallback.

## Reproduction (live Autotask)

```
POST /Companies/query            -> 200, 500 items, nextPageUrl=/Companies/query/next?paging=...
GET  /Companies/query/next?...   -> 405  "does not support http method 'GET'"
POST /Companies/query/next?... + {filter}  -> 200, next 500 items   ✅
```

Server log from the broken path:

```
Failed to refresh company cache: Autotask GET .../Companies/query/next?paging=... failed:
HTTP 405: {"Message":"The requested resource does not support http method 'GET'."}
  at MappingService.initializeCache → listAllCompanies
```

## Fix

In `query()`, page with `POST` on `nextPageUrl` and forward the original
filter body (the paging cursor is in the URL, the filter goes in the body):

```ts
- resp = await this.request<QueryResponse<T>>('GET', resp.pageDetails.nextPageUrl);
+ resp = await this.request<QueryResponse<T>>('POST', resp.pageDetails.nextPageUrl, body);
```

`request()` already handles absolute URLs and request bodies, so this is a
one-line behavioral change.

## Validation (live Autotask)

After the fix, the company cache pre-warms completely:

```
Retrieved 4110 companies via listAllCompanies
Mapping cache initialized successfully  companies: 4110, resources: 25
```

(Previously: cache empty, repeated 405s.) A 25-row contracts search then
resolves 25/25 company names from cache.

## Tests

- Updated the existing cursor-pagination mocks in `tests/autotask-service.test.ts`
  — they encoded the buggy `GET`-on-next-page behavior; they now expect `POST`.
- Added a regression test asserting the next-page request is a `POST` that
  carries the filter body.
- `npm run build` ✓ · `tsc --noEmit` ✓ · `eslint src` ✓ (0 errors) ·
  `npm test` ✓ **133 passed**.

## Notes

- Independent of (and complementary to) the enrichment-concurrency fix: with a
  working cache, most name lookups are cache hits; the concurrency bound covers
  the remaining per-record fallbacks. Either fix alone reduces 429 pressure;
  together they eliminate it.

## Related

- Same root cause class as #9 (AutoTask returns HTTP 405 on `GET` of a list
  endpoint and requires a `POST` query) — that fix covered direct list calls;
  this covers the cursor `nextPageUrl`, which still issued a `GET`.
- Follows #101 / #102, which fixed the company-cache page *slicing* and added
  `listAllCompanies`, but left the pagination HTTP method unchanged. On tenants
  with >500 companies the pre-warm still fails at the first cursor hop.
