### PR TITLE
ci: bump docs deploy to Node 22 for Astro 6

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
       - name: Install dependencies


### PR DESCRIPTION
## Summary

`Deploy Docs` has been **failing on `main` since 2026-06-08** (#140, which bumped Astro to `^6.4.4`). Astro 6 requires **Node `>=22.12.0`**, but the build job still pinned `node-version: 20`, so `npx astro build` aborts:

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

The failure was silent because the workflow only runs on `website/**` / `deploy-docs.yml` changes — it surfaced when #171 (the actions bump) touched `deploy-docs.yml` and re-triggered it.

## Fix

Bump the docs build job to `node-version: 22` (installs `>=22.12.0`). One line; restores docs deploys.

## Testing

Merging re-triggers `Deploy Docs` (this PR edits `deploy-docs.yml`), which will confirm `npx astro build` succeeds on Node 22.