### PR TITLE
ci: bump remaining Node 20 actions (codecov v7, upload-pages-artifact v5)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build site
         working-directory: website
         run: npx astro build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: website/dist
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,10 @@ jobs:
         run: npm run test:coverage
       
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4.6.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false 


### PR DESCRIPTION
## Summary

Follow-up to #171 / #173. A runtime audit of every action in this repo's workflows found three more on Node 20; this clears the two that have a Node 24 version available.

| Action | Before | After | Notes |
|---|---|---|---|
| `codecov/codecov-action` | v4.6.0 (node20) | **v7.0.0** (composite) | v5+ is a CLI-wrapper composite with no Node runtime; v7 renamed `file`→`files` (updated) |
| `actions/upload-pages-artifact` | v3 → `upload-artifact@v4` (node20) | **v5.0.0** → `upload-artifact@v7` (node24) | fixes the transitive deprecation Deploy Docs surfaced |

### Not bumped (no fix available yet)
- **`github/codeql-action` (upload-sarif)** — even the latest `v3` is still `node20`; GitHub hasn't shipped a node24 build. Safe to leave: Node 20 isn't removed from runners until **2026-09-16**. Worth a tracking note to revisit.

## Already on Node 24 (no change needed)
`actions/deploy-pages`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action`.

## Compatibility
- codecov v7 supports every input we pass (`files`, `flags`, `name`, `fail_ci_if_error`, `token`); only `file`→`files` changed.
- `upload-pages-artifact` input is still `path:` — unchanged.

## Testing
- `Code Quality` job exercises the new codecov upload on this PR.
- Merging re-triggers `Deploy Docs` (edits `deploy-docs.yml`), validating `upload-pages-artifact@v5`.