### PR TITLE
ci: bump central reusable-workflow pins to Node 24 (canary)

### DIFF
--- a/.github/workflows/mcp-assert.yml
+++ b/.github/workflows/mcp-assert.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   assert:
-    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@17b5a183964aa163d82e9f7092186086e97bc70e  # main
+    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0  # main
     with:
       entry: dist/entry.js
       canary-tool: autotask_test_connection

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   spam:
-    uses: wyre-technology/.github/.github/workflows/pr-spam-triage.yml@03d64fcdcce377f8a8d86ef9b66b125dc8156149  # main
+    uses: wyre-technology/.github/.github/workflows/pr-spam-triage.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0  # main
     with:
       # Start in dry-run: label spam-suspected PRs but don't close.
       # Flip to false after a verification window (~1 week) of zero false positives.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Test
     # Delegated to the canonical reusable CI workflow.
     # See: ~/.claude/skills/mcp-server-fleet-ci-template
-    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@8f1da6a78d0cc0b8a330547bfc6892da3e72ae13
+    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
     with:
       node-versions: '["20", "22"]'
       lint-destructive-warnings: true
@@ -226,7 +226,7 @@ jobs:
       contents: read
     # Delegates to the canonical reusable workflow so the digest-pinned + correct-ACA
     # deploy logic lives in one place across every wyre-technology/*-mcp repo.
-    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@d6ace529b210900f460cb365529f2a552daedf7a
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
     with:
       vendor-slug: autotask
       image-name: ghcr.io/wyre-technology/autotask-mcp


### PR DESCRIPTION
## Summary

Re-pins this repo's shared reusable workflows to **`198605d`** — the [wyre-technology/.github#24](https://github.com/wyre-technology/.github/pull/24) commit that bumped every deprecated Node 20 action to a Node 24 build.

| Reusable workflow | Old pin | New pin |
|---|---|---|
| `mcp-server-ci.yml` | `8f1da6a` | **`198605d`** |
| `mcp-server-deploy.yml` | `d6ace52` | **`198605d`** |
| `mcp-assert.yml` | `17b5a18` | **`198605d`** |
| `pr-spam-triage.yml` | `03d64fc` | **`198605d`** |

`auto-add-to-project.yml` is pinned `@main` and already tracks the change.

## Why this PR

This is the **canary** for the fleet-wide pin bump. The central reusable workflows can only be validated by a consumer running them, so we prove them here — on a real CI + release + deploy — before rolling the same `@198605d` pin out to the other ~52 `*-mcp` repos.

## What this exercises

- `mcp-server-ci.yml` → bumped checkout/setup-node/setup-buildx/build-push (this PR's own CI run)
- `mcp-server-deploy.yml` → bumped `azure/login` v2→v3 (on the next release/deploy)
- `mcp-assert.yml` → bumped checkout/setup-node
- `pr-spam-triage.yml` → bumped `github-script` v7→v8 (on PR triage events)