### PR TITLE
feat(ci): add configurationItemType and configurationItemCategoryID filters to search_configuration_items

### DIFF
--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -2108,6 +2108,14 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'number',
           description: 'Filter by product ID'
         },
+        configurationItemType: {
+          type: 'number',
+          description: 'Filter by configuration item type (numeric picklist value)'
+        },
+        configurationItemCategoryID: {
+          type: 'number',
+          description: 'Filter by configuration item category ID'
+        },
         pageSize: {
           type: 'number',
           description: 'Number of results to return (default: 25, max: 500)',

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -873,6 +873,8 @@ export class AutotaskService {
       pushEq(filters, 'companyID', o.companyID);
       pushEq(filters, 'isActive', o.isActive);
       pushEq(filters, 'productID', o.productID);
+      pushEq(filters, 'configurationItemType', o.configurationItemType);
+      pushEq(filters, 'configurationItemCategoryID', o.configurationItemCategoryID);
       if (o.searchTerm) {
         filters.push({ op: 'contains', field: 'referenceTitle', value: o.searchTerm });
       }

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -880,6 +880,20 @@ describe('AutotaskService', () => {
       expect(body.filter).toContainEqual({ op: 'contains', field: 'referenceTitle', value: 'laptop' });
     });
 
+    test('searchConfigurationItems translates configurationItemType and configurationItemCategoryID', async () => {
+      const capture = captureFilter('ConfigurationItems');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchConfigurationItems({
+        companyID: 999,
+        configurationItemType: 2,
+        configurationItemCategoryID: 5,
+      } as any);
+      const body = capture();
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'companyID', value: 999 });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'configurationItemType', value: 2 });
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'configurationItemCategoryID', value: 5 });
+    });
+
     test('searchInvoices translates companyID, invoiceNumber, isVoided', async () => {
       const capture = captureFilter('Invoices');
       const service = new AutotaskService(configWithUrl, mockLogger);


### PR DESCRIPTION
## Summary

Adds `configurationItemType` and `configurationItemCategoryID` as optional filter parameters to the `autotask_search_configuration_items` tool.

Both fields are supported natively by the Autotask API query body but were previously unavailable through the MCP tool. Without them, the only workaround is pulling all active CIs for a company and filtering client-side — wasteful for companies with large CI counts.

## Changes

- `src/handlers/tool.definitions.ts` — adds two new properties to the tool's input schema
- `src/services/autotask.service.ts` — adds `pushEq` calls for both fields in `searchConfigurationItems`
- `tests/autotask-service.test.ts` — adds a filter-translation test covering the two new params, matching the pattern established in #104/#105

## Testing

**Unit tests:** new test `searchConfigurationItems translates configurationItemType and configurationItemCategoryID` added alongside the existing filter-translation regression suite. All 46 tests pass.

**Live testing against Autotask API:**
- Filtered by `configurationItemType` across two companies (domain type, server type) — each returned only CIs of the correct type, count matched prior full-company pulls
- Filtered by `configurationItemCategoryID` across three distinct categories and two companies — all returned correctly scoped results, cross-validated against known counts
- Both filters return server-side filtered results; no client-side workaround needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)