### PR TITLE
feat: unified ticket activity tool + time-entry name resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:mapping-simple": "tsx scripts/test-mapping-simple.js",
     "lint": "eslint src",
     "lint:fix": "eslint src --ext .ts --fix",
-    "clean": "rm -rf dist",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "prepare": "npm run build",
     "prebuild": "npm run clean",
     "pretest": "npm run build",

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -2512,6 +2512,10 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'number',
           description: 'Filter by resource (user) ID'
         },
+        resourceName: {
+          type: 'string',
+          description: 'Filter by resource (user) name, e.g. "Melissa Jones". Resolved to a resourceID automatically — use this when you have a name instead of an ID. Each returned entry includes summaryNotes (the work description) and resourceName.'
+        },
         ticketId: {
           type: 'number',
           description: 'Filter by ticket ID'
@@ -2554,6 +2558,34 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         }
       },
       required: []
+    }
+  },
+  {
+    name: 'autotask_get_ticket_activity',
+    description: 'Get the COMPLETE activity for one ticket in a single call: ticket details, every note (what was said), every time entry (what was done — with who, hours, and the work description), and the change history — merged into one chronological timeline with names resolved. Use this for any "what happened / what was said / what was done on ticket X" question, so the user never has to ask for notes and time entries separately. Returns { ticket, timeline[], counts, hoursTotal }.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketID: {
+          type: 'number',
+          description: 'The ticket ID to retrieve all activity for.'
+        },
+        includeHistory: {
+          type: 'boolean',
+          description: 'Include the ticket change-history audit trail (status/assignment/field changes). Default true.'
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Max records pulled from each source (notes, time entries, history). Default 100, max 500.',
+          minimum: 1,
+          maximum: 500
+        }
+      },
+      required: ['ticketID']
+    },
+    annotations: {
+      title: 'Get ticket activity (notes + time + history)',
+      readOnlyHint: true
     }
   },
 
@@ -3065,7 +3097,7 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
   },
   tickets: {
     description: 'Search, create, update tickets and manage ticket notes, attachments, charges, and audit history',
-    tools: ['autotask_search_tickets', 'autotask_get_ticket_details', 'autotask_create_ticket', 'autotask_update_ticket', 'autotask_get_ticket_note', 'autotask_search_ticket_notes', 'autotask_create_ticket_note', 'autotask_get_ticket_attachment', 'autotask_search_ticket_attachments', 'autotask_create_ticket_attachment', 'autotask_get_ticket_charge', 'autotask_search_ticket_charges', 'autotask_create_ticket_charge', 'autotask_update_ticket_charge', 'autotask_delete_ticket_charge', 'autotask_get_ticket_history', 'autotask_search_ticket_history']
+    tools: ['autotask_search_tickets', 'autotask_get_ticket_details', 'autotask_get_ticket_activity', 'autotask_create_ticket', 'autotask_update_ticket', 'autotask_get_ticket_note', 'autotask_search_ticket_notes', 'autotask_create_ticket_note', 'autotask_get_ticket_attachment', 'autotask_search_ticket_attachments', 'autotask_create_ticket_attachment', 'autotask_get_ticket_charge', 'autotask_search_ticket_charges', 'autotask_create_ticket_charge', 'autotask_update_ticket_charge', 'autotask_delete_ticket_charge', 'autotask_get_ticket_history', 'autotask_search_ticket_history']
   },
   projects: {
     description: 'Search and create projects, tasks, phases, and project notes',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -147,6 +147,24 @@ export class AutotaskToolHandler {
               if (name) result.lead = name;
             } catch { /* skip */ }
           }
+          // Time entries reference their technician via resourceID (not
+          // assignedResourceID), so resolve that to a name too — otherwise a
+          // time entry comes back as a bare number and callers can't tell who
+          // logged the work.
+          if (item.resourceID != null && typeof item.resourceID === 'number') {
+            try {
+              const name = await mappingService.getResourceName(item.resourceID);
+              if (name) result.resourceName = name;
+            } catch { /* skip */ }
+          }
+          // Notes record their author via createdByResourceID — resolve it so
+          // "who said this" shows a name, not a number.
+          if (item.createdByResourceID != null && typeof item.createdByResourceID === 'number') {
+            try {
+              const name = await mappingService.getResourceName(item.createdByResourceID);
+              if (name) result.createdByName = name;
+            } catch { /* skip */ }
+          }
           return result;
         }
       );
@@ -1382,8 +1400,20 @@ export class AutotaskToolHandler {
 
       // Time Entries
       ['autotask_search_time_entries', async (a) => {
+        // Allow filtering by resource NAME (e.g. "Melissa Jones"), mirroring
+        // autotask_create_time_entry. Without this, callers must first look up
+        // the numeric resourceID via autotask_search_resources before they can
+        // find a specific person's time entries.
+        let resourceId = a.resourceId;
+        if (resourceId == null && a.resourceName) {
+          const resource = await s.resolveResourceByName(a.resourceName);
+          if (!resource) {
+            throw new Error(`No resource found matching "${a.resourceName}"`);
+          }
+          resourceId = resource.id;
+        }
         const r = await s.searchTimeEntries({
-          resourceId: a.resourceId,
+          resourceId,
           ticketId: a.ticketId,
           projectId: a.projectId,
           taskId: a.taskId,
@@ -1395,6 +1425,88 @@ export class AutotaskToolHandler {
           pageSize: a.pageSize
         } as any);
         return { result: r, message: `Found ${r.length} time entries` };
+      }],
+
+      // Ticket Activity — unified "what happened on this ticket" view.
+      // Aggregates ticket details + notes (what was said) + time entries (what
+      // was done) + change history into ONE chronological timeline, so callers
+      // never have to ask for each source separately. Sources are fetched in
+      // parallel and each is guarded so one failure doesn't sink the whole view.
+      ['autotask_get_ticket_activity', async (a) => {
+        const ticketId = a.ticketID ?? a.ticketId;
+        if (ticketId == null) {
+          throw new Error('ticketID is required');
+        }
+        const pageSize = Math.min(a.pageSize || 100, 500);
+        const includeHistory = a.includeHistory !== false;
+
+        const [ticket, notesRaw, timeRaw, historyRaw] = await Promise.all([
+          s.getTicket(ticketId, true).catch(() => null),
+          s.searchTicketNotes(ticketId, { pageSize }).catch(() => [] as any[]),
+          s.searchTimeEntries({ ticketId, pageSize } as any).catch(() => [] as any[]),
+          includeHistory
+            ? s.searchTicketHistory({ ticketId, pageSize }).catch(() => [] as any[])
+            : Promise.resolve([] as any[]),
+        ]);
+
+        if (!ticket) {
+          return { result: null, message: `No ticket found with ID ${ticketId}` };
+        }
+
+        // Resolve resource/company names on every collection up front.
+        const [ticketEnh] = await this.enhanceItems([ticket]);
+        const notes = await this.enhanceItems(notesRaw);
+        const timeEntries = await this.enhanceItems(timeRaw);
+        const history = await this.enhanceItems(historyRaw);
+
+        // Merge everything into one chronological timeline.
+        const timeline: Array<Record<string, any>> = [];
+        for (const n of notes) {
+          timeline.push({
+            date: n.createDate,
+            type: 'note',
+            who: n.createdByName ?? (n.createdByResourceID != null ? `Resource ${n.createdByResourceID}` : undefined),
+            title: n.title,
+            summary: n.description,
+            noteId: n.id,
+          });
+        }
+        for (const t of timeEntries) {
+          timeline.push({
+            date: t.dateWorked,
+            type: 'time_entry',
+            who: t.resourceName ?? (t.resourceID != null ? `Resource ${t.resourceID}` : undefined),
+            hours: t.hoursWorked,
+            summary: t.summaryNotes,
+            timeEntryId: t.id,
+          });
+        }
+        for (const h of history) {
+          timeline.push({
+            date: h.dateChanged,
+            type: 'history',
+            who: h.resourceName ?? (h.resourceID != null ? `Resource ${h.resourceID}` : undefined),
+            summary: h.description ?? h.title ?? undefined,
+            historyId: h.id,
+          });
+        }
+        // Ascending by date; undated entries sort to the end.
+        timeline.sort((x, y) => String(x.date ?? '~').localeCompare(String(y.date ?? '~')));
+
+        const hoursTotal = timeEntries.reduce(
+          (sum: number, t: any) => sum + (typeof t.hoursWorked === 'number' ? t.hoursWorked : 0),
+          0
+        );
+
+        const result = {
+          ticket: ticketEnh,
+          timeline,
+          counts: { notes: notes.length, timeEntries: timeEntries.length, history: history.length },
+          hoursTotal,
+        };
+        const parts = [`${notes.length} notes`, `${timeEntries.length} time entries`];
+        if (includeHistory) parts.push(`${history.length} history entries`);
+        return { result, message: `Ticket ${ticketId}: ${parts.join(', ')}, ${hoursTotal}h logged` };
       }],
 
       // Meta-tools for progressive discovery


### PR DESCRIPTION
- Add autotask_get_ticket_activity: ticket details + notes + time entries + history merged into one chronological timeline with names resolved.

- Resolve resourceID (time-entry technician) and createdByResourceID (note author) to names in enhanceItems.

- Add resourceName filter to autotask_search_time_entries.

## Summary

<!-- What does this PR change, and why? -->

## Changes

<!-- A short list of the notable changes. -->

-

## Testing

<!-- How was this verified? Commands run, tests added, manual checks. -->

-

## Checklist

- [ ] The change is described clearly above and the reason for it is stated.
- [ ] Tests were added or updated where it makes sense, and the existing suite passes.
- [ ] Documentation (README, comments, CHANGELOG) is updated if behavior changed.
- [ ] No secrets, credentials, or tokens are included in the diff.
- [ ] The commit messages follow the repository's convention.
