### PR TITLE
fix(tickets): use noteq operator so open ticket search excludes Complete

### DIFF
--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -351,7 +351,7 @@ export class AutotaskService {
       if (options.status !== undefined) {
         filters.push({ op: 'eq', field: 'status', value: options.status });
       } else {
-        filters.push({ op: 'ne', field: 'status', value: 5 }); // 5 = Complete
+        filters.push({ op: 'noteq', field: 'status', value: 5 }); // 5 = Complete
       }
 
       if (options.unassigned === true) {


### PR DESCRIPTION
## Summary

The Complete filter for tickets was using an invalid parameter.

## Changes

Update query parameter in open ticket search from "ne" to "noteq"


## Testing

Verified against a live tenant (filter assignedResourceID eq X):
- {op:'ne', field:'status', value:5} returned 500 rows, 100% with status=5 (Complete) - filter dropped
- {op:'noteq', field:'status', value:5} returned 20 rows, zero Complete  - correct


## Checklist

- [x] The change is described clearly above and the reason for it is stated.
- [ ] Tests were added or updated where it makes sense, and the existing suite passes.
- [ ] Documentation (README, comments, CHANGELOG) is updated if behavior changed.
- [x] No secrets, credentials, or tokens are included in the diff.
- [x] The commit messages follow the repository's convention.
