### PR TITLE
feat: fix ticket resource assignment, expand update_ticket fields, ad…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Give your AI assistant direct access to Autotask.** Search tickets, create time entries, look up companies, manage projects — all through natural language. No more copy-pasting between browser tabs and chat windows.
 
-This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that connects Claude (or any MCP-compatible AI) to your Autotask PSA environment. Your AI assistant gets 39 tools covering the operations MSP teams use daily: ticket triage, time logging, company lookups, project management, billing review, and more.
+This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that connects Claude (or any MCP-compatible AI) to your Autotask PSA environment. Your AI assistant gets 102 tools covering the operations MSP teams use daily: ticket triage, time logging, company lookups, project management, billing review, and more.
 
 If you run an MSP on Autotask and you're tired of the context-switching tax, this is for you.
 
@@ -55,7 +55,7 @@ See [Installation](#installation) for Docker and from-source methods.
 ## Features
 
 - **🔌 MCP Protocol Compliance**: Full support for MCP resources and tools
-- **🛠️ Comprehensive API Coverage**: 39 tools spanning companies, contacts, tickets, projects, billing items, time entries, notes, attachments, and more
+- **🛠️ Comprehensive API Coverage**: 102 tools spanning companies, contacts, tickets, projects, billing items, time entries, notes, attachments, and more
 - **🔍 Advanced Search**: Powerful search capabilities with filters across all entities
 - **📝 CRUD Operations**: Create, read, update operations for core Autotask entities
 - **🔄 ID-to-Name Mapping**: Automatic resolution of company and resource IDs to human-readable names
@@ -316,7 +316,7 @@ Resources provide read-only access to Autotask data:
 
 ### Tools
 
-The server provides 39 tools for interacting with Autotask:
+The server provides 102 tools for interacting with Autotask:
 
 #### Company Operations
 - `autotask_search_companies` - Search companies with filters
@@ -330,7 +330,11 @@ The server provides 39 tools for interacting with Autotask:
 #### Ticket Operations
 - `autotask_search_tickets` - Search tickets with filters
 - `autotask_get_ticket_details` - Get full ticket details by ID
-- `autotask_create_ticket` - Create new ticket
+- `autotask_create_ticket` - Create new ticket (supports assignment, type/subtype, queue, category, source, due date)
+- `autotask_update_ticket` - Update ticket (status, priority, assignment, type/subtype, queue, category, resolution, and more)
+- `autotask_search_ticket_secondary_resources` / `autotask_create_ticket_secondary_resource` / `autotask_delete_ticket_secondary_resource` - Manage additional technicians on a ticket
+
+When assigning a resource (`assignedResourceID`) without an explicit `assignedResourceRoleID`, the server automatically resolves the resource's default role — Autotask requires a role with every assignment.
 
 #### Time Entry Operations
 - `autotask_create_time_entry` - Log time entry
@@ -347,6 +351,7 @@ The server provides 39 tools for interacting with Autotask:
 
 #### Resource Operations
 - `autotask_search_resources` - Search resources (technicians/users)
+- `autotask_search_resource_roles` - Discover valid role IDs for a resource (needed for ticket assignment)
 
 #### Note Operations
 - `autotask_get_ticket_note` / `autotask_search_ticket_notes` / `autotask_create_ticket_note`

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -523,11 +523,11 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         },
         assignedResourceID: {
           type: 'number',
-          description: 'Assigned resource ID. If set, assignedResourceRoleID is also required by Autotask.'
+          description: 'Assigned resource ID. Autotask requires assignedResourceRoleID alongside this; if omitted, the resource\'s default role is resolved and filled in automatically.'
         },
         assignedResourceRoleID: {
           type: 'number',
-          description: 'Role ID for the assigned resource. Required by Autotask when assignedResourceID is set.'
+          description: 'Role ID for the assigned resource. Optional — auto-resolved from the resource\'s default role when omitted. Use autotask_search_resource_roles to discover valid values.'
         },
         contactID: {
           type: 'number',
@@ -572,6 +572,10 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         projectID: {
           type: 'number',
           description: 'Project ID to associate the ticket with. Links the ticket to an existing project.'
+        },
+        dueDateTime: {
+          type: 'string',
+          description: 'Due date and time in ISO 8601 format (e.g. 2026-03-15T17:00:00Z)'
         },
         ticketAdditionalContacts: {
           type: 'array',
@@ -626,11 +630,11 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         },
         assignedResourceID: {
           type: 'number',
-          description: 'Assigned resource ID. If set, assignedResourceRoleID is also required by Autotask.'
+          description: 'Assigned resource ID. Autotask requires assignedResourceRoleID alongside this; if omitted, the resource\'s default role is resolved and filled in automatically.'
         },
         assignedResourceRoleID: {
           type: 'number',
-          description: 'Role ID for the assigned resource. Required by Autotask when assignedResourceID is set.'
+          description: 'Role ID for the assigned resource. Optional — auto-resolved from the resource\'s default role when omitted. Use autotask_search_resource_roles to discover valid values.'
         },
         dueDateTime: {
           type: 'string',
@@ -647,9 +651,133 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         subIssueType: {
           type: 'number',
           description: 'Sub issue type ID (picklist). Must be valid for the selected issueType. Use autotask_get_field_info (entity "Tickets", field "subIssueType") to discover valid values.'
+        },
+        queueID: {
+          type: 'number',
+          description: 'Queue ID to route the ticket to. Use autotask_list_queues to discover valid IDs.'
+        },
+        ticketCategory: {
+          type: 'number',
+          description: 'Ticket category ID (picklist). Use autotask_get_field_info with entity "Tickets" and field "ticketCategory" to discover valid values.'
+        },
+        ticketType: {
+          type: 'number',
+          description: 'Ticket type ID (picklist, e.g. Service Request, Incident, Problem, Change).'
+        },
+        source: {
+          type: 'number',
+          description: 'Ticket source ID (picklist, e.g. Phone, Email, Portal). Use autotask_get_field_info (entity "Tickets", field "source") to discover valid values.'
+        },
+        billingCodeID: {
+          type: 'number',
+          description: 'Work type / billing code ID used for billing this ticket.'
+        },
+        serviceLevelAgreementID: {
+          type: 'number',
+          description: 'Service Level Agreement (SLA) ID to apply to the ticket.'
+        },
+        estimatedHours: {
+          type: 'number',
+          description: 'Estimated hours of work for the ticket.'
+        },
+        projectID: {
+          type: 'number',
+          description: 'Project ID to associate the ticket with. Links the ticket to an existing project.'
+        },
+        resolution: {
+          type: 'string',
+          description: 'Ticket-level resolution text. This is the Resolution field on the ticket itself, NOT a ticket note.'
+        },
+        userDefinedFields: {
+          type: 'array',
+          description: 'User-defined (custom) fields for the ticket, as an array of { name, value } objects matching the Autotask REST API shape.',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', description: 'UDF name' },
+              value: { type: 'string', description: 'UDF value (stringified)' }
+            },
+            required: ['name', 'value']
+          }
         }
       },
       required: ['ticketId']
+    }
+  },
+
+  // Ticket Secondary Resource tools
+  {
+    name: 'autotask_search_ticket_secondary_resources',
+    description: 'Search secondary resource (technician) assignments on tickets. Provide ticketId for best performance.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: {
+          type: 'number',
+          description: 'Filter by ticket ID (recommended)'
+        },
+        resourceId: {
+          type: 'number',
+          description: 'Filter by resource (technician) ID'
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Number of results to return (default: 25)',
+          minimum: 1,
+          maximum: 200
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: 'autotask_create_ticket_secondary_resource',
+    description: 'Add a secondary resource (additional technician) to a ticket, alongside the primary assignedResourceID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketID: {
+          type: 'number',
+          description: 'The ticket ID to add the secondary resource to'
+        },
+        resourceID: {
+          type: 'number',
+          description: 'The resource (technician) ID to add'
+        },
+        roleID: {
+          type: 'number',
+          description: 'Role ID for the resource on this ticket. Optional — auto-resolved from the resource\'s default role when omitted. Use autotask_search_resource_roles to discover valid values.'
+        }
+      },
+      required: ['ticketID', 'resourceID']
+    }
+  },
+  {
+    name: 'autotask_delete_ticket_secondary_resource',
+    description:
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Permanently removes a secondary resource ' +
+      'assignment from a ticket. This action cannot be undone. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Remove ticket secondary resource assignment (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ticketId: {
+          type: 'number',
+          description: 'The ticket ID the secondary resource belongs to'
+        },
+        secondaryResourceId: {
+          type: 'number',
+          description: 'The ticket secondary resource record ID to delete (from autotask_search_ticket_secondary_resources, NOT the resource ID)'
+        }
+      },
+      required: ['ticketId', 'secondaryResourceId']
     }
   },
 
@@ -1091,6 +1219,34 @@ export const TOOL_DEFINITIONS: McpTool[] = [
         pageSize: {
           type: 'number',
           description: 'Max 500',
+          minimum: 1,
+          maximum: 500
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: 'autotask_search_resource_roles',
+    description: 'Search resource-role associations. Use this to discover valid role IDs for a resource before assigning them to a ticket (assignedResourceRoleID) or adding them as a secondary resource.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        resourceId: {
+          type: 'number',
+          description: 'Filter by resource (technician) ID'
+        },
+        roleId: {
+          type: 'number',
+          description: 'Filter by role ID'
+        },
+        isActive: {
+          type: 'boolean',
+          description: 'Filter by active state (true recommended when looking up assignable roles)'
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Number of results to return (default: 25, max: 500)',
           minimum: 1,
           maximum: 500
         }
@@ -3072,8 +3228,8 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
     tools: ['autotask_search_contacts', 'autotask_create_contact']
   },
   tickets: {
-    description: 'Search, create, update tickets and manage ticket notes, attachments, charges, and audit history',
-    tools: ['autotask_search_tickets', 'autotask_get_ticket_details', 'autotask_create_ticket', 'autotask_update_ticket', 'autotask_get_ticket_note', 'autotask_search_ticket_notes', 'autotask_create_ticket_note', 'autotask_get_ticket_attachment', 'autotask_search_ticket_attachments', 'autotask_create_ticket_attachment', 'autotask_get_ticket_charge', 'autotask_search_ticket_charges', 'autotask_create_ticket_charge', 'autotask_update_ticket_charge', 'autotask_delete_ticket_charge', 'autotask_get_ticket_history', 'autotask_search_ticket_history']
+    description: 'Search, create, update tickets and manage ticket notes, attachments, charges, secondary resources, and audit history',
+    tools: ['autotask_search_tickets', 'autotask_get_ticket_details', 'autotask_create_ticket', 'autotask_update_ticket', 'autotask_search_ticket_secondary_resources', 'autotask_create_ticket_secondary_resource', 'autotask_delete_ticket_secondary_resource', 'autotask_get_ticket_note', 'autotask_search_ticket_notes', 'autotask_create_ticket_note', 'autotask_get_ticket_attachment', 'autotask_search_ticket_attachments', 'autotask_create_ticket_attachment', 'autotask_get_ticket_charge', 'autotask_search_ticket_charges', 'autotask_create_ticket_charge', 'autotask_update_ticket_charge', 'autotask_delete_ticket_charge', 'autotask_get_ticket_history', 'autotask_search_ticket_history']
   },
   projects: {
     description: 'Search and create projects, tasks, phases, and project notes',
@@ -3092,8 +3248,8 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
     tools: ['autotask_get_product', 'autotask_search_products', 'autotask_get_service', 'autotask_search_services', 'autotask_get_service_bundle', 'autotask_search_service_bundles']
   },
   resources: {
-    description: 'Search for Autotask resources (technicians/staff)',
-    tools: ['autotask_search_resources']
+    description: 'Search for Autotask resources (technicians/staff) and their role associations',
+    tools: ['autotask_search_resources', 'autotask_search_resource_roles']
   },
   configuration_items: {
     description: 'Search configuration items (assets/devices)',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -30,6 +30,8 @@ const TICKET_WRITABLE_FIELDS = [
   'status',
   'priority',
   'assignedResourceID',
+  'assignedResourceRoleID',
+  'dueDateTime',
   'contactID',
   'queueID',
   'ticketCategory',
@@ -112,6 +114,26 @@ export class AutotaskToolHandler {
       });
     }
     return this.mappingService;
+  }
+
+  /**
+   * Autotask rejects any ticket write that sets assignedResourceID without
+   * assignedResourceRoleID. When the caller supplied only the resource,
+   * resolve the resource's default role and fill it in so assignment "just
+   * works". Leaves the payload untouched when nothing can be resolved —
+   * Autotask's own validation error is more actionable than ours.
+   */
+  private async fillAssignedResourceRole(payload: Record<string, any>): Promise<void> {
+    if (payload.assignedResourceID === undefined || payload.assignedResourceRoleID !== undefined) {
+      return;
+    }
+    const roleId = await this.autotaskService.resolveDefaultRoleForResource(payload.assignedResourceID);
+    if (roleId !== null) {
+      payload.assignedResourceRoleID = roleId;
+      this.logger.debug(
+        `Auto-resolved assignedResourceRoleID=${roleId} for resource ${payload.assignedResourceID}`
+      );
+    }
   }
 
   /**
@@ -846,12 +868,14 @@ export class AutotaskToolHandler {
       }],
       ['autotask_create_ticket', async (a) => {
         const payload = buildTicketPayload(a);
+        await this.fillAssignedResourceRole(payload);
         const id = await s.createTicket(payload);
         return { result: id, message: `Successfully created ticket with ID: ${id}` };
       }],
       ['autotask_update_ticket', async (a) => {
         const { ticketId, ...rest } = a;
         const payload = buildTicketPayload(rest);
+        await this.fillAssignedResourceRole(payload);
         await s.updateTicket(ticketId, payload);
         return { result: ticketId, message: `Successfully updated ticket ${ticketId}` };
       }],
@@ -873,6 +897,28 @@ export class AutotaskToolHandler {
         const { chargeId, ...updates } = a;
         await s.updateTicketCharge(chargeId, updates);
         return { result: chargeId, message: `Successfully updated ticket charge ${chargeId}` };
+      }],
+      // Ticket Secondary Resources
+      ['autotask_search_ticket_secondary_resources', async (a) => {
+        const r = await s.searchTicketSecondaryResources(a);
+        return { result: r, message: `Found ${r.length} ticket secondary resources` };
+      }],
+      ['autotask_create_ticket_secondary_resource', async (a) => {
+        const payload: Record<string, any> = {
+          ticketID: a.ticketID,
+          resourceID: a.resourceID,
+          ...(a.roleID !== undefined && { roleID: a.roleID })
+        };
+        if (payload.roleID === undefined) {
+          const roleId = await s.resolveDefaultRoleForResource(a.resourceID);
+          if (roleId !== null) payload.roleID = roleId;
+        }
+        const id = await s.createTicketSecondaryResource(payload);
+        return { result: id, message: `Successfully added secondary resource with ID: ${id}` };
+      }],
+      ['autotask_delete_ticket_secondary_resource', async (a) => {
+        await s.deleteTicketSecondaryResource(a.ticketId, a.secondaryResourceId);
+        return { result: a.secondaryResourceId, message: `Successfully removed ticket secondary resource ${a.secondaryResourceId}` };
       }],
       ['autotask_delete_ticket_charge', async (a) => {
         await s.deleteTicketCharge(a.ticketId, a.chargeId);
@@ -1021,6 +1067,10 @@ export class AutotaskToolHandler {
       // Resources
       ['autotask_search_resources', async (a) => {
         const r = await s.searchResources(a); return { result: r, message: `Found ${r.length} resources` };
+      }],
+      ['autotask_search_resource_roles', async (a) => {
+        const r = await s.searchResourceRoles(a);
+        return { result: r, message: `Found ${r.length} resource roles` };
       }],
 
       // Configuration Items

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -44,6 +44,8 @@ import {
   AutotaskServiceCall,
   AutotaskServiceCallTicket,
   AutotaskServiceCallTicketResource,
+  AutotaskResourceRole,
+  AutotaskTicketSecondaryResource,
   AutotaskPhase
 } from '../types/autotask';
 import { McpServerConfig } from '../types/mcp';
@@ -546,6 +548,62 @@ export class AutotaskService {
   }
 
   // =====================================================
+  // Ticket Secondary Resources (child of Tickets)
+  // =====================================================
+
+  async searchTicketSecondaryResources(
+    options: { ticketId?: number; resourceId?: number; pageSize?: number } = {}
+  ): Promise<AutotaskTicketSecondaryResource[]> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug('Searching ticket secondary resources with options:', options);
+      const filters: QueryFilter[] = [];
+      pushEq(filters, 'ticketID', options.ticketId);
+      pushEq(filters, 'resourceID', options.resourceId);
+      const pageSize = Math.min(options.pageSize || 25, 200);
+      const items = await http.query<AutotaskTicketSecondaryResource>(
+        'TicketSecondaryResources',
+        filters.length > 0 ? filters : MATCH_ALL,
+        { maxRecords: pageSize }
+      );
+      this.logger.info(`Retrieved ${items.length} ticket secondary resources`);
+      return items;
+    } catch (error) {
+      this.logger.error('Failed to search ticket secondary resources:', error);
+      throw error;
+    }
+  }
+
+  async createTicketSecondaryResource(data: Partial<AutotaskTicketSecondaryResource>): Promise<number> {
+    const http = await this.ensureClient();
+    try {
+      if (!data.ticketID) {
+        throw new Error('ticketID is required to create a ticket secondary resource');
+      }
+      this.logger.debug('Creating ticket secondary resource:', data);
+      // TicketSecondaryResources is a child entity — create via parent URL.
+      const id = await http.childCreate('Tickets', data.ticketID, 'SecondaryResources', data);
+      this.logger.info(`Ticket secondary resource created with ID: ${id}`);
+      return id;
+    } catch (error) {
+      this.logger.error('Failed to create ticket secondary resource:', error);
+      throw error;
+    }
+  }
+
+  async deleteTicketSecondaryResource(ticketId: number, secondaryResourceId: number): Promise<void> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug(`Deleting ticket secondary resource ${secondaryResourceId} from ticket ${ticketId}`);
+      await http.childDelete('Tickets', ticketId, 'SecondaryResources', secondaryResourceId);
+      this.logger.info(`Ticket secondary resource ${secondaryResourceId} deleted`);
+    } catch (error) {
+      this.logger.error(`Failed to delete ticket secondary resource ${secondaryResourceId}:`, error);
+      throw error;
+    }
+  }
+
+  // =====================================================
   // Ticket History (read-only audit trail of field changes)
   // =====================================================
 
@@ -844,6 +902,58 @@ export class AutotaskService {
     } catch (error) {
       this.logger.error('Failed to search resources:', error);
       throw error;
+    }
+  }
+
+  // =====================================================
+  // Resource Roles
+  // =====================================================
+
+  async searchResourceRoles(
+    options: { resourceId?: number; roleId?: number; isActive?: boolean; pageSize?: number } = {}
+  ): Promise<AutotaskResourceRole[]> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug('Searching resource roles with options:', options);
+      const filters: QueryFilter[] = [];
+      pushEq(filters, 'resourceID', options.resourceId);
+      pushEq(filters, 'roleID', options.roleId);
+      pushEq(filters, 'isActive', options.isActive);
+      const pageSize = Math.min(options.pageSize || 25, 500);
+      const roles = await http.query<AutotaskResourceRole>(
+        'ResourceRoles',
+        filters.length > 0 ? filters : MATCH_ALL,
+        { maxRecords: pageSize }
+      );
+      this.logger.info(`Retrieved ${roles.length} resource roles`);
+      return roles;
+    } catch (error) {
+      this.logger.error('Failed to search resource roles:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Resolve a role ID to use when assigning `resourceId` to a ticket and the
+   * caller did not supply assignedResourceRoleID (Autotask requires one
+   * whenever assignedResourceID is set). Prefers the resource's default
+   * service desk role; falls back to the resource's first active
+   * ResourceRoles entry. Returns null when nothing can be resolved — the
+   * caller should let Autotask reject the request with its own error.
+   */
+  async resolveDefaultRoleForResource(resourceId: number): Promise<number | null> {
+    try {
+      const resource = await this.getResource(resourceId);
+      const defaultRole = (resource as any)?.defaultServiceDeskRoleID;
+      if (typeof defaultRole === 'number' && defaultRole > 0) {
+        return defaultRole;
+      }
+      const roles = await this.searchResourceRoles({ resourceId, isActive: true, pageSize: 1 });
+      const roleId = roles[0]?.roleID;
+      return typeof roleId === 'number' ? roleId : null;
+    } catch (error) {
+      this.logger.warn(`Could not resolve default role for resource ${resourceId}:`, error);
+      return null;
     }
   }
 

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -40,6 +40,7 @@ export interface AutotaskTicket {
   companyID?: number;
   contactID?: number;
   assignedResourceID?: number;
+  assignedResourceRoleID?: number;
   title?: string;
   description?: string;
   status?: number;
@@ -77,6 +78,24 @@ export interface AutotaskResource {
   title?: string;
   resourceType?: number;
   userType?: number;
+  [key: string]: any;
+}
+
+export interface AutotaskResourceRole {
+  id?: number;
+  resourceID?: number;
+  roleID?: number;
+  departmentID?: number;
+  queueID?: number;
+  isActive?: boolean;
+  [key: string]: any;
+}
+
+export interface AutotaskTicketSecondaryResource {
+  id?: number;
+  ticketID?: number;
+  resourceID?: number;
+  roleID?: number;
   [key: string]: any;
 }
 

--- a/tests/ticket-assignment.test.ts
+++ b/tests/ticket-assignment.test.ts
@@ -1,0 +1,206 @@
+// Regression tests for ticket resource assignment and type/subtype support:
+// - assignedResourceRoleID and dueDateTime were declared in the tool schemas
+//   but silently stripped by the TICKET_WRITABLE_FIELDS whitelist, so every
+//   assignment attempt failed Autotask validation (role required with resource).
+// - autotask_update_ticket's schema hid ticketType/queueID/ticketCategory/etc.
+//   even though the whitelist would pass them through.
+// - When only assignedResourceID is supplied, the handler auto-resolves the
+//   resource's default role so assignment works without a role lookup.
+
+jest.mock('autotask-node', () => ({
+  AutotaskClient: {
+    create: jest.fn().mockRejectedValue(new Error('Mock: Cannot connect to Autotask API'))
+  }
+}));
+
+import { TOOL_DEFINITIONS, TOOL_CATEGORIES } from '../src/handlers/tool.definitions';
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+
+const mockConfig: McpServerConfig = {
+  name: 'test-server',
+  version: '1.0.0',
+  autotask: {
+    username: 'test-username',
+    secret: 'test-secret',
+    integrationCode: 'test-integration-code'
+  }
+};
+
+const mockLogger = new Logger('error');
+
+function buildHandler() {
+  const service = new AutotaskService(mockConfig, mockLogger);
+  const handler = new AutotaskToolHandler(service, mockLogger, false);
+  return { service, handler };
+}
+
+describe('ticket assignment payload passthrough', () => {
+  test('create_ticket forwards assignedResourceRoleID and dueDateTime', async () => {
+    const { service, handler } = buildHandler();
+    const createTicket = jest.spyOn(service, 'createTicket').mockResolvedValue(42);
+
+    await handler.callTool('autotask_create_ticket', {
+      companyID: 1,
+      title: 't',
+      description: 'd',
+      assignedResourceID: 7,
+      assignedResourceRoleID: 99,
+      dueDateTime: '2026-08-01T17:00:00Z'
+    });
+
+    expect(createTicket).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignedResourceID: 7,
+        assignedResourceRoleID: 99,
+        dueDateTime: '2026-08-01T17:00:00Z'
+      })
+    );
+  });
+
+  test('update_ticket forwards type/subtype/queue/category and role fields', async () => {
+    const { service, handler } = buildHandler();
+    const updateTicket = jest.spyOn(service, 'updateTicket').mockResolvedValue(undefined);
+
+    await handler.callTool('autotask_update_ticket', {
+      ticketId: 5,
+      assignedResourceID: 7,
+      assignedResourceRoleID: 99,
+      ticketType: 2,
+      issueType: 10,
+      subIssueType: 136,
+      queueID: 8,
+      ticketCategory: 3,
+      source: 4,
+      dueDateTime: '2026-08-01T17:00:00Z'
+    });
+
+    expect(updateTicket).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        assignedResourceID: 7,
+        assignedResourceRoleID: 99,
+        ticketType: 2,
+        issueType: 10,
+        subIssueType: 136,
+        queueID: 8,
+        ticketCategory: 3,
+        source: 4,
+        dueDateTime: '2026-08-01T17:00:00Z'
+      })
+    );
+  });
+
+  test('auto-resolves the default role when only assignedResourceID is given', async () => {
+    const { service, handler } = buildHandler();
+    jest.spyOn(service, 'resolveDefaultRoleForResource').mockResolvedValue(31);
+    const createTicket = jest.spyOn(service, 'createTicket').mockResolvedValue(42);
+
+    await handler.callTool('autotask_create_ticket', {
+      companyID: 1,
+      title: 't',
+      description: 'd',
+      assignedResourceID: 7
+    });
+
+    expect(service.resolveDefaultRoleForResource).toHaveBeenCalledWith(7);
+    expect(createTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ assignedResourceID: 7, assignedResourceRoleID: 31 })
+    );
+  });
+
+  test('does not override an explicitly provided role', async () => {
+    const { service, handler } = buildHandler();
+    const resolve = jest.spyOn(service, 'resolveDefaultRoleForResource');
+    const updateTicket = jest.spyOn(service, 'updateTicket').mockResolvedValue(undefined);
+
+    await handler.callTool('autotask_update_ticket', {
+      ticketId: 5,
+      assignedResourceID: 7,
+      assignedResourceRoleID: 99
+    });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(updateTicket).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({ assignedResourceRoleID: 99 })
+    );
+  });
+
+  test('leaves payload untouched when no role can be resolved', async () => {
+    const { service, handler } = buildHandler();
+    jest.spyOn(service, 'resolveDefaultRoleForResource').mockResolvedValue(null);
+    const createTicket = jest.spyOn(service, 'createTicket').mockResolvedValue(42);
+
+    await handler.callTool('autotask_create_ticket', {
+      companyID: 1,
+      title: 't',
+      description: 'd',
+      assignedResourceID: 7
+    });
+
+    const payload = createTicket.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.assignedResourceRoleID).toBeUndefined();
+  });
+});
+
+describe('update_ticket schema exposes categorization fields', () => {
+  const def = TOOL_DEFINITIONS.find(t => t.name === 'autotask_update_ticket')!;
+  const props = (def.inputSchema as { properties: Record<string, unknown> }).properties;
+
+  test.each([
+    'ticketType', 'queueID', 'ticketCategory', 'source', 'billingCodeID',
+    'serviceLevelAgreementID', 'estimatedHours', 'projectID', 'resolution',
+    'userDefinedFields', 'assignedResourceID', 'assignedResourceRoleID', 'dueDateTime'
+  ])('%s is present', (field) => {
+    expect(props[field]).toBeDefined();
+  });
+});
+
+describe('resource role and secondary resource tools', () => {
+  const toolNames = new Set(TOOL_DEFINITIONS.map(t => t.name));
+
+  test('new tools are defined and categorized', () => {
+    for (const name of [
+      'autotask_search_resource_roles',
+      'autotask_search_ticket_secondary_resources',
+      'autotask_create_ticket_secondary_resource',
+      'autotask_delete_ticket_secondary_resource'
+    ]) {
+      expect(toolNames.has(name)).toBe(true);
+    }
+    expect(TOOL_CATEGORIES.resources.tools).toContain('autotask_search_resource_roles');
+    expect(TOOL_CATEGORIES.tickets.tools).toContain('autotask_create_ticket_secondary_resource');
+  });
+
+  test('delete_ticket_secondary_resource is marked destructive', () => {
+    const def = TOOL_DEFINITIONS.find(t => t.name === 'autotask_delete_ticket_secondary_resource')!;
+    expect(def.annotations?.destructiveHint).toBe(true);
+  });
+
+  test('create_ticket_secondary_resource auto-resolves role when omitted', async () => {
+    const { service, handler } = buildHandler();
+    jest.spyOn(service, 'resolveDefaultRoleForResource').mockResolvedValue(31);
+    const create = jest.spyOn(service, 'createTicketSecondaryResource').mockResolvedValue(77);
+
+    await handler.callTool('autotask_create_ticket_secondary_resource', {
+      ticketID: 5,
+      resourceID: 7
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ ticketID: 5, resourceID: 7, roleID: 31 })
+    );
+  });
+
+  test('search_ticket_secondary_resources routes filters to the service', async () => {
+    const { service, handler } = buildHandler();
+    const search = jest.spyOn(service, 'searchTicketSecondaryResources').mockResolvedValue([]);
+
+    await handler.callTool('autotask_search_ticket_secondary_resources', { ticketId: 5 });
+
+    expect(search).toHaveBeenCalledWith(expect.objectContaining({ ticketId: 5 }));
+  });
+});


### PR DESCRIPTION
…d resource roles + secondary resources

- Add assignedResourceRoleID and dueDateTime to TICKET_WRITABLE_FIELDS — both were declared in the create/update ticket tool schemas but silently stripped from the payload, so every assignment attempt failed Autotask validation (a role is required whenever a resource is set)
- Auto-resolve the resource's default role (defaultServiceDeskRoleID, falling back to the first active ResourceRoles entry) when a ticket write sets assignedResourceID without assignedResourceRoleID
- Expose ticketType, queueID, ticketCategory, source, billingCodeID, serviceLevelAgreementID, estimatedHours, projectID, resolution, and userDefinedFields on autotask_update_ticket (previously create-only)
- Add dueDateTime to autotask_create_ticket
- New tool: autotask_search_resource_roles for discovering valid role IDs
- New tools: search/create/delete ticket secondary resources for multi-technician tickets (TicketSecondaryResources child entity)
- Document new tools in README and refresh stale tool count


Claude-Session: https://claude.ai/code/session_01MjwwLPF8MhDsjkpBt2Ddrw

## Summary

<!-- What does this PR change, and why? -->

## Changes

<!-- A short list of the notable changes. -->

-

## Testing

<!-- How was this verified? Commands run, tests added, manual checks. -->

-

## Checklist

- [ ] The change is described clearly above and the reason for it is stated.
- [ ] Tests were added or updated where it makes sense, and the existing suite passes.
- [ ] Documentation (README, comments, CHANGELOG) is updated if behavior changed.
- [ ] No secrets, credentials, or tokens are included in the diff.
- [ ] The commit messages follow the repository's convention.
