### PR TITLE
ci: adopt codeql-action v4 (node24) via reusable-workflow pin bump (#176)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,11 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write  # required by reusable release job: @semantic-release/github success step reads/comments on associated PRs
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a925b43adb22aa8885b8243e1056e6a42cdce4d1
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@d28a612a00a1bd0c36aff09e686ce2d1e10ef552
     with:
       server-name: autotask-mcp
       image-name: ghcr.io/wyre-technology/autotask-mcp


### PR DESCRIPTION
Resolves #176 in this repo.

The codeql-action pin lives in the centralized reusable workflow (`wyre-technology/.github`), fixed in wyre-technology/.github#39 (v3.35.3 → v4.37.3, node20 → node24). This repo consumes that workflow at a pinned SHA, so it only picks up the fix once the pin is bumped.

## Changes
- Bump `mcp-server-release.yml` reusable pin `a925b43` → `d28a612` (current `.github` main; carries the codeql v4 bump).
- Add `pull-requests: write` to the `release` job permissions. The `d28a612` reusable release job declares `pull-requests: write` for `@semantic-release/github`'s success step (associated-PR read/comment); a reusable workflow can only *reduce* caller-granted scope, so the caller must grant it — this is the documented "CALLER PROPAGATION (REQUIRED)" step. Without it, a release that sweeps PRs would `FORBIDDEN`-fail.

The pin range adopts exactly #34 (release perms) + #39 (codeql v4) for `release.yml`. The security-scan/codeql step runs post-release and is non-blocking.