### PR TITLE
feat: migrate to MCP SDK v2 with dual-era (backward-compatible) serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 ## [Unreleased]
 
+### Changed
+
+- **Migrated from `@modelcontextprotocol/sdk` v1 to the v2 SDK (`@modelcontextprotocol/server` + `@modelcontextprotocol/node` 2.0.0-beta.5) with dual-era serving.** All three entrypoints now consume one shared per-request server factory (`AutotaskMcpServer.requestFactory()`), so the tool/resource/prompt surface can never drift between protocol eras:
+  - **stdio** is served via `serveStdio(factory)` — the opening handshake pins the connection to its era (classic 2025 `initialize` or modern 2026-07-28).
+  - **Node HTTP** is served via `createMcpHandler(factory, { legacy: 'stateless' })` wrapped with `toNodeHandler`. Modern 2026-07-28 envelope traffic is served natively; 2025-era traffic is served by the SDK's default stateless legacy fallback — a fresh server per request, the same per-request stateless idiom this server has always used. CORS, `/health`, and the gateway 401 credential gate are unchanged.
+  - **Cloudflare Workers** uses the same `createMcpHandler` (memoized per isolate) through its web-standard `fetch` face, replacing the hand-wired `WebStandardStreamableHTTPServerTransport` per-request plumbing.
+  - The gateway credential contract is byte-identical: `X-API-Key`, `X-API-Secret`, `X-Integration-Code`, and optional `X-API-Url` headers are read per request (now from the handler's `ctx.requestInfo`) and bind an isolated per-tenant `AutotaskService`; missing credentials in gateway mode still answer 401 before any MCP processing.
+  - The tool surface is unchanged: same 98 tool names and input schemas from `tool.definitions.ts` served to both eras (pinned by `scripts/smoke-dual-era.mjs`).
+  - Wire-visible behavior notes for legacy (2025-era) clients: successful POST responses now arrive as single-message `text/event-stream` SSE frames instead of plain JSON bodies (both are canonical Streamable HTTP; every spec-conforming client accepts SSE), and GET/DELETE session operations on `/mcp` answer 405 from inside the SDK's stateless fallback rather than from hand-rolled routing.
+  - Internal API renames: `McpError`/`ErrorCode` → `ProtocolError`/`ProtocolErrorCode`, `setRequestHandler(SomeRequestSchema, …)` → `setRequestHandler('method/name', …)`. Local result types tightened to the v2 SDK's literal-typed wire shapes (`inputSchema.type: 'object'`, content `type: 'text'`, resource contents text-xor-blob).
+
 ### Added
+
+- **Dual-era smoke test** (`scripts/smoke-dual-era.mjs`): boots the built HTTP server with dummy credentials and proves a hand-crafted 2025-era JSON-RPC client (classic `initialize` → `notifications/initialized` → `tools/list`) and a modern `@modelcontextprotocol/client@2` StreamableHTTP session both see the identical non-empty tool surface. Exits non-zero on any failure.
 
 - **Interactive ticket card via MCP Apps (SEP-1865).** `autotask_get_ticket_details` results now render as an interactive card in MCP Apps hosts (Claude Desktop/web, and other hosts advertising the `io.modelcontextprotocol/ui` extension), instead of a wall of JSON. The card shows status/priority/queue as human-readable labels, company and assignee names, dates, and recent notes — and includes a working "Add note" round-trip that calls `autotask_create_ticket_note` from inside the card. Non-App hosts are unaffected: the tool's JSON payload is unchanged apart from a new `_card` field.
   - The card is **brand-neutral by default** (system fonts, neutral palette, no baked-in identity — this is a published server) and brandable without rebuilding: `MCP_BRAND_NAME`, `MCP_BRAND_LOGO_URL`, `MCP_BRAND_PRIMARY_COLOR`, `MCP_BRAND_ACCENT_COLOR`, `MCP_BRAND_BG`, and `MCP_BRAND_TEXT` env vars are injected as `window.__BRAND__` at serve time (a gateway can inject the same object per-org). A test pins the default bundle to zero brand identity and zero external font fetches.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@anthropic-ai/mcpb": "^2.1.2",
         "@eslint/js": "^10.0.1",
+        "@modelcontextprotocol/client": "^2.0.0-beta.5",
         "@modelcontextprotocol/ext-apps": "^1.7.3",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
@@ -2558,6 +2559,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.5.tgz",
+      "integrity": "sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@modelcontextprotocol/core": {
@@ -7388,7 +7408,6 @@
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -7402,7 +7421,6 @@
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -9875,7 +9893,6 @@
       "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -13576,7 +13593,6 @@
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.18.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/node": "^2.0.0-beta.5",
+        "@modelcontextprotocol/server": "^2.0.0-beta.5",
         "winston": "^3.11.0",
         "zod": "^4.4.3"
       },
@@ -2559,6 +2560,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.5.tgz",
+      "integrity": "sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/ext-apps": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
@@ -2589,11 +2602,34 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0-beta.5.tgz",
+      "integrity": "sha512-flrOzx5qFLBM9I8IYRGfYUY02erFmxOvYQ9sEE6iSj/ZZpRYKorXWscM/qrfW9rwlcGLyymHhnP2AaDbMB1lIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0-beta.5",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2627,6 +2663,19 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.5.tgz",
+      "integrity": "sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.5",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -4811,6 +4860,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -4871,7 +4921,9 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4887,7 +4939,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -5417,6 +5471,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -5618,6 +5673,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5627,6 +5683,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5640,6 +5697,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6144,6 +6202,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6157,6 +6216,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6246,6 +6306,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6255,6 +6316,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -6271,6 +6333,7 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -6355,6 +6418,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6473,6 +6537,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6588,6 +6653,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6666,6 +6732,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6730,6 +6797,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -6776,6 +6844,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6986,6 +7055,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6995,6 +7065,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7004,6 +7075,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7084,6 +7156,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -7303,6 +7376,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7312,7 +7386,9 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -7324,7 +7400,9 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -7441,6 +7519,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -7484,6 +7563,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -7574,6 +7654,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -7594,6 +7675,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7604,7 +7686,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -7695,6 +7778,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -7897,6 +7981,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7906,6 +7991,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8082,6 +8168,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8167,6 +8254,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8214,6 +8302,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -8306,6 +8395,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8357,6 +8447,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8385,6 +8476,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8408,6 +8500,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.24.tgz",
       "integrity": "sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8462,6 +8555,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -8520,6 +8614,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8736,6 +8831,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8745,6 +8841,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -8854,6 +8951,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -8892,6 +8990,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/issue-parser": {
@@ -9774,7 +9873,9 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
       "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -9890,13 +9991,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10486,6 +10591,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10502,6 +10608,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10524,6 +10631,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10573,6 +10681,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10582,6 +10691,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -10787,6 +10897,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13000,6 +13111,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13009,6 +13121,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13021,6 +13134,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -13033,6 +13147,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -13341,6 +13456,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -13370,6 +13486,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13396,6 +13513,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -13456,7 +13574,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -13771,6 +13891,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -13832,6 +13953,7 @@
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -13847,6 +13969,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13856,6 +13979,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -14104,6 +14228,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14212,6 +14337,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -14257,6 +14383,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -14675,6 +14802,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -14701,6 +14829,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -14727,12 +14856,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14745,6 +14876,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14754,6 +14886,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14773,6 +14906,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14789,6 +14923,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14807,6 +14942,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15180,6 +15316,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15797,6 +15934,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -16019,6 +16157,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -16158,6 +16297,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -16364,6 +16504,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -17059,6 +17200,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -17170,6 +17312,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -17408,6 +17551,7 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
   "author": "Aaron Sachs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "winston": "^3.11.0",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "@modelcontextprotocol/server": "^2.0.0-beta.5",
+    "@modelcontextprotocol/node": "^2.0.0-beta.5"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -42,15 +42,16 @@
   "author": "Aaron Sachs",
   "license": "Apache-2.0",
   "dependencies": {
-    "winston": "^3.11.0",
-    "zod": "^4.4.3",
+    "@modelcontextprotocol/node": "^2.0.0-beta.5",
     "@modelcontextprotocol/server": "^2.0.0-beta.5",
-    "@modelcontextprotocol/node": "^2.0.0-beta.5"
+    "winston": "^3.11.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.2",
-    "@modelcontextprotocol/ext-apps": "^1.7.3",
     "@eslint/js": "^10.0.1",
+    "@modelcontextprotocol/client": "^2.0.0-beta.5",
+    "@modelcontextprotocol/ext-apps": "^1.7.3",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.8",

--- a/scripts/smoke-dual-era.mjs
+++ b/scripts/smoke-dual-era.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Dual-era smoke test: proves the HTTP entrypoint serves BOTH protocol eras
+// after the @modelcontextprotocol v2 migration.
+//
+//   (a) LEGACY leg — hand-crafted 2025-era JSON-RPC POSTs (the classic
+//       initialize handshake, no per-request envelope): initialize →
+//       notifications/initialized → tools/list.
+//   (b) MODERN leg — @modelcontextprotocol/client@2 (StreamableHTTP
+//       transport, 2026-07-28 negotiation): connect → tools/list.
+//
+// Both legs must see the same non-empty tool surface. Exits non-zero on any
+// failure. Run from the repo root after `npm run build`:
+//
+//   node scripts/smoke-dual-era.mjs
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const serverEntry = resolve(root, 'dist/index.js');
+const PORT = 38700 + Math.floor(Math.random() * 200);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const failures = [];
+function check(label, ok, detail = '') {
+  const status = ok ? 'PASS' : 'FAIL';
+  console.log(`  [${status}] ${label}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) failures.push(label);
+}
+
+/** Parse a Streamable HTTP response body: plain JSON or a single-message SSE stream. */
+async function mcpBody(res) {
+  const text = await res.text();
+  const contentType = res.headers.get('content-type') ?? '';
+  if (contentType.includes('text/event-stream')) {
+    const dataLines = text.split('\n').filter((line) => line.startsWith('data:'));
+    const last = dataLines[dataLines.length - 1];
+    if (!last) throw new Error(`No data frame in SSE body: ${JSON.stringify(text)}`);
+    return JSON.parse(last.slice('data:'.length).trim());
+  }
+  return JSON.parse(text);
+}
+
+async function legacyPost(body) {
+  return fetch(`${BASE}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function waitForHealth(timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${BASE}/health`);
+      if (res.ok) return res.json();
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Server did not become healthy on ${BASE} within ${timeoutMs}ms`);
+}
+
+async function legacyLeg() {
+  console.log('\nLEGACY leg (2025-era classic JSON-RPC handshake):');
+
+  // 1. initialize with a 2025 protocolVersion — the pre-envelope handshake.
+  const initRes = await legacyPost({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-03-26',
+      capabilities: {},
+      clientInfo: { name: 'smoke-legacy', version: '0.0.0' },
+    },
+  });
+  check('initialize HTTP 200', initRes.status === 200, `status=${initRes.status}`);
+  const init = await mcpBody(initRes);
+  const result = init?.result;
+  check(
+    'InitializeResult has protocolVersion + serverInfo + capabilities',
+    typeof result?.protocolVersion === 'string' &&
+      result?.serverInfo?.name === 'autotask-mcp' &&
+      typeof result?.capabilities === 'object',
+    `protocolVersion=${result?.protocolVersion} serverInfo=${result?.serverInfo?.name}`
+  );
+
+  // 2. notifications/initialized — must be accepted (202 in Streamable HTTP).
+  const notifRes = await legacyPost({
+    jsonrpc: '2.0',
+    method: 'notifications/initialized',
+  });
+  check(
+    'notifications/initialized accepted',
+    notifRes.status >= 200 && notifRes.status < 300,
+    `status=${notifRes.status}`
+  );
+
+  // 3. tools/list — the tool surface must be non-empty.
+  const toolsRes = await legacyPost({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/list',
+    params: {},
+  });
+  check('tools/list HTTP 200', toolsRes.status === 200, `status=${toolsRes.status}`);
+  const tools = (await mcpBody(toolsRes))?.result?.tools ?? [];
+  check('tools/list returns >0 tools', tools.length > 0, `count=${tools.length}`);
+  return tools;
+}
+
+async function modernLeg() {
+  console.log('\nMODERN leg (@modelcontextprotocol/client v2, 2026-07-28 era):');
+  const { Client, StreamableHTTPClientTransport } = await import(
+    '@modelcontextprotocol/client'
+  );
+
+  const client = new Client({ name: 'smoke-modern', version: '0.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL(`${BASE}/mcp`));
+  await client.connect(transport);
+  check('client connected', true);
+
+  const { tools } = await client.listTools();
+  check('tools/list returns >0 tools', tools.length > 0, `count=${tools.length}`);
+  await client.close();
+  return tools;
+}
+
+async function main() {
+  if (!existsSync(serverEntry)) {
+    console.error(`Missing ${serverEntry} — run 'npm run build' first.`);
+    process.exit(1);
+  }
+
+  console.log(`Starting HTTP server on ${BASE} (env-mode dummy credentials)...`);
+  const child = spawn(process.execPath, [serverEntry], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: 'http',
+      MCP_HTTP_PORT: String(PORT),
+      MCP_HTTP_HOST: '127.0.0.1',
+      AUTOTASK_USERNAME: 'smoke@example.com',
+      AUTOTASK_SECRET: 'dummy-secret',
+      AUTOTASK_INTEGRATION_CODE: 'DUMMYCODE',
+      LOG_LEVEL: 'error',
+      LOG_FORMAT: 'simple',
+    },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+
+  try {
+    const health = await waitForHealth();
+    check('health probe ok', health?.status === 'ok', `version=${health?.version}`);
+
+    const legacyTools = await legacyLeg();
+    const modernTools = await modernLeg();
+
+    console.log('\nCross-era comparison:');
+    check(
+      'both eras serve the same tool count',
+      legacyTools.length === modernTools.length,
+      `legacy=${legacyTools.length} modern=${modernTools.length}`
+    );
+    const legacyNames = new Set(legacyTools.map((t) => t.name));
+    const modernNames = new Set(modernTools.map((t) => t.name));
+    const drift = [...legacyNames]
+      .filter((n) => !modernNames.has(n))
+      .concat([...modernNames].filter((n) => !legacyNames.has(n)));
+    check('both eras serve the same tool names', drift.length === 0, drift.join(', ') || 'no drift');
+  } catch (error) {
+    check('smoke run completed without exception', false, String(error));
+  } finally {
+    child.kill('SIGTERM');
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nSMOKE FAILED: ${failures.length} check(s) failed: ${failures.join('; ')}`);
+    process.exit(1);
+  }
+  console.log('\nSMOKE PASSED: both protocol eras served by the same factory.');
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('Smoke script crashed:', error);
+  process.exit(1);
+});

--- a/src/handlers/resource.handler.ts
+++ b/src/handlers/resource.handler.ts
@@ -18,12 +18,13 @@ export interface McpResource {
   mimeType?: string;
 }
 
-export interface McpResourceContent {
-  uri: string;
-  mimeType: string;
-  text?: string;
-  blob?: string;
-}
+// text XOR blob, matching the v2 SDK's resources/read result type, which
+// requires exactly one of the two to be present. The `?: never` form keeps
+// `.text` / `.blob` accessible without narrowing.
+export type McpResourceContent = { uri: string; mimeType: string } & (
+  | { text: string; blob?: never }
+  | { blob: string; text?: never }
+);
 
 export class AutotaskResourceHandler {
   private autotaskService: AutotaskService;

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -1,7 +1,7 @@
+import { Server } from "@modelcontextprotocol/server";
+
 // Autotask Tool Handler
 // Handles MCP tool calls for Autotask operations (search, create, update)
-
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { AutotaskService } from '../services/autotask.service.js';
 import { AutotaskRateLimitError } from '../services/autotask-http.js';
 import { PicklistCache, PicklistValue } from '../services/picklist.cache.js';

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -61,7 +61,9 @@ export interface McpTool {
   name: string;
   description: string;
   inputSchema: {
-    type: string;
+    // Literal 'object' (not string): the v2 SDK's tools/list result type
+    // requires the JSON Schema type discriminant as a literal.
+    type: 'object';
     properties: Record<string, any>;
     required?: string[];
   };
@@ -78,7 +80,7 @@ export interface McpTool {
 
 export interface McpToolResult {
   content: Array<{
-    type: string;
+    type: 'text';
     text: string;
   }>;
   isError?: boolean;

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -1,14 +1,10 @@
+import { Server } from "@modelcontextprotocol/server";
+
 // MCP Prompt Handlers for Autotask MCP Server
 // Exposes pre-baked prompt templates via ListPrompts and GetPrompt handlers
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import {
-  ListPromptsRequestSchema,
-  GetPromptRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-
 export function registerPromptHandlers(server: Server): void {
-  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+  server.setRequestHandler('prompts/list', async () => ({
     prompts: [
       {
         name: 'ticket-queue-review',
@@ -72,7 +68,7 @@ export function registerPromptHandlers(server: Server): void {
     ],
   }));
 
-  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  server.setRequestHandler('prompts/get', async (request) => {
     const { name, arguments: args } = request.params;
 
     switch (name) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,10 +1,22 @@
 // Main MCP Server Implementation
-import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
-import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
-import { Server, Transport, ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/server";
-
 // Handles the Model Context Protocol server setup and integration with Autotask
 // Supports both local (env-based) and gateway (header-based) credential modes
+//
+// Serving is built on the v2 SDK's dual-era entries: one shared
+// McpServerFactory feeds createMcpHandler (HTTP, modern 2026-07-28 envelope
+// traffic natively + 2025-era traffic via the default stateless legacy
+// fallback) and serveStdio (stdio, same factory, era pinned per connection).
+
+import {
+  createMcpHandler,
+  Server,
+  ProtocolError,
+  ProtocolErrorCode,
+  type McpHttpHandler,
+  type McpServerFactory,
+} from '@modelcontextprotocol/server';
+import { serveStdio, type StdioServerHandle } from '@modelcontextprotocol/server/stdio';
+import { toNodeHandler } from '@modelcontextprotocol/node';
 
 import { createServer, IncomingMessage, ServerResponse, Server as HttpServer } from 'node:http';
 import { AutotaskService } from '../services/autotask.service.js';
@@ -16,7 +28,6 @@ import { AutotaskToolHandler } from '../handlers/tool.handler.js';
 import { registerPromptHandlers } from './prompts.js';
 
 export class AutotaskMcpServer {
-  private server: Server;
   private config: McpServerConfig;
   private autotaskService: AutotaskService;
   private resourceHandler: AutotaskResourceHandler;
@@ -24,6 +35,8 @@ export class AutotaskMcpServer {
   private logger: Logger;
   private envConfig: EnvironmentConfig | undefined;
   private httpServer?: HttpServer;
+  private mcpHandler: McpHttpHandler | undefined;
+  private stdioHandle: StdioServerHandle | undefined;
   private lazyLoading: boolean;
 
   constructor(config: McpServerConfig, logger: Logger, envConfig?: EnvironmentConfig) {
@@ -38,9 +51,30 @@ export class AutotaskMcpServer {
     // Initialize handlers
     this.resourceHandler = new AutotaskResourceHandler(this.autotaskService, logger);
     this.toolHandler = new AutotaskToolHandler(this.autotaskService, logger, this.lazyLoading);
+  }
 
-    // Create default server (used for stdio mode)
-    this.server = this.createFreshServer();
+  /**
+   * The shared per-request/per-connection server factory consumed by every
+   * serving entry (createMcpHandler for Node HTTP and Workers, serveStdio for
+   * stdio). One factory backs both protocol eras, so the tool surface can
+   * never drift between legacy (2025) and modern (2026-07-28) clients.
+   *
+   * In gateway mode, per-request credentials are read from the inbound HTTP
+   * request's headers (ctx.requestInfo) — the exact same X-API-Key /
+   * X-API-Secret / X-Integration-Code / X-API-Url contract as before. stdio
+   * connections have no requestInfo and always use env-configured credentials.
+   */
+  public requestFactory(): McpServerFactory {
+    const isGatewayMode = this.envConfig?.auth?.mode === 'gateway';
+    return (ctx) => {
+      let credentials: GatewayCredentials | undefined;
+      if (isGatewayMode && ctx.requestInfo) {
+        credentials = parseCredentialsFromHeaders(
+          Object.fromEntries(ctx.requestInfo.headers) as Record<string, string | undefined>
+        );
+      }
+      return this.createRequestServer(credentials);
+    };
   }
 
   /**
@@ -242,10 +276,15 @@ export class AutotaskMcpServer {
 
   /**
    * Start with stdio transport (default)
+   *
+   * serveStdio owns the era decision for the connection: a classic 2025
+   * `initialize` handshake pins a legacy-era instance, a modern opening pins
+   * a 2026-07-28 instance — both built by the same factory.
    */
   private async startStdioTransport(): Promise<void> {
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
+    this.stdioHandle = serveStdio(this.requestFactory(), {
+      onerror: (error) => this.logger.error('MCP stdio serving error:', error),
+    });
     this.logger.info('Autotask MCP Server started and connected to stdio transport');
   }
 
@@ -257,6 +296,19 @@ export class AutotaskMcpServer {
     const port = this.envConfig?.transport?.port || 8080;
     const host = this.envConfig?.transport?.host || '0.0.0.0';
     const isGatewayMode = this.envConfig?.auth?.mode === 'gateway';
+
+    // One dual-era handler for the process: modern (2026-07-28 envelope)
+    // traffic is served natively; legacy 2025-era traffic is served by the
+    // default stateless fallback ('stateless') — a fresh factory-built server
+    // per request, exactly the per-request stateless idiom this server has
+    // always used. Legacy GET/DELETE session operations answer 405 by design.
+    this.mcpHandler = createMcpHandler(this.requestFactory(), {
+      legacy: 'stateless',
+      onerror: (error) => this.logger.error('MCP handler error:', error),
+    });
+    const nodeMcpHandler = toNodeHandler(this.mcpHandler, {
+      onerror: (error) => this.logger.error('MCP node adapter error:', error),
+    });
 
     this.httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
       const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
@@ -298,36 +350,18 @@ export class AutotaskMcpServer {
         return;
       }
 
-      // MCP endpoint — stateless: fresh server + transport per request
+      // MCP endpoint — dual-era handler (fresh factory-built server per
+      // request in both eras; nothing is shared between requests)
       if (url.pathname === '/mcp') {
-        // Only POST is supported in stateless mode
-        if (req.method !== 'POST') {
-          res.writeHead(405, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({
-            jsonrpc: '2.0',
-            error: { code: -32000, message: 'Method not allowed' },
-            id: null,
-          }));
-          return;
-        }
-
-        // In gateway mode, build per-request service + handlers from the
-        // injected credential headers. Each request gets its own isolated
-        // AutotaskService so concurrent requests for different tenants
-        // never interfere with each other.
-        let perRequestToolHandler: AutotaskToolHandler | undefined;
-        let perRequestResourceHandler: AutotaskResourceHandler | undefined;
+        // In gateway mode, require the injected credential headers up front.
+        // Falling through to the env-configured handlers would serve the
+        // server operator's tenant data to whoever sent the unauthenticated
+        // request — a cross-tenant leak. Reject explicitly instead. The
+        // factory re-reads the same headers from ctx.requestInfo to build the
+        // per-request, tenant-isolated AutotaskService.
         if (isGatewayMode) {
           const credentials = parseCredentialsFromHeaders(req.headers as Record<string, string | string[] | undefined>);
-          if (credentials.username && credentials.secret && credentials.integrationCode) {
-            const handlers = this.buildPerRequestHandlers(credentials);
-            perRequestToolHandler = handlers.toolHandler;
-            perRequestResourceHandler = handlers.resourceHandler;
-          } else {
-            // Gateway mode REQUIRES per-request credentials. Falling through
-            // to the env-configured `this.toolHandler` would serve the server
-            // operator's tenant data to whoever sent the unauthenticated
-            // request — a cross-tenant leak. Reject explicitly instead.
+          if (!credentials.username || !credentials.secret || !credentials.integrationCode) {
             res.writeHead(401, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({
               jsonrpc: '2.0',
@@ -341,20 +375,13 @@ export class AutotaskMcpServer {
           }
         }
 
-        // Stateless: create fresh server + transport for each request
-        const server = this.createFreshServer(perRequestToolHandler, perRequestResourceHandler);
-        const transport = new NodeStreamableHTTPServerTransport({
-          enableJsonResponse: true,
-        });
-
-        res.on('close', () => {
-          transport.close();
-          server.close();
-        });
-
-        server.connect(transport as unknown as Transport).then(() => {
-          transport.handleRequest(req, res);
-        }).catch((err) => {
+        // Delegate to the dual-era handler. Legacy (2025) traffic is served
+        // per-request statelessly; modern (2026-07-28) traffic natively.
+        // Legacy-era GET/DELETE answer 405 inside the handler, as before.
+        // Cast: the adapter's duck-typed NodeIncomingMessageLike declares
+        // `method?: string`, which node:http's IncomingMessage doesn't satisfy
+        // under exactOptionalPropertyTypes (v2.0.0-beta.5 typings papercut).
+        nodeMcpHandler(req as unknown as Parameters<typeof nodeMcpHandler>[0], res).catch((err) => {
           this.logger.error('MCP transport error:', err);
           if (!res.headersSent) {
             res.writeHead(500, { 'Content-Type': 'application/json' });
@@ -394,7 +421,14 @@ export class AutotaskMcpServer {
         this.httpServer!.close((err) => err ? reject(err) : resolve());
       });
     }
-    await this.server.close();
+    if (this.mcpHandler) {
+      await this.mcpHandler.close();
+      this.mcpHandler = undefined;
+    }
+    if (this.stdioHandle) {
+      await this.stdioHandle.close();
+      this.stdioHandle = undefined;
+    }
     this.logger.info('Autotask MCP Server stopped');
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,21 +1,12 @@
 // Main MCP Server Implementation
+import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { Server, Transport, ProtocolError, ProtocolErrorCode } from "@modelcontextprotocol/server";
+
 // Handles the Model Context Protocol server setup and integration with Autotask
 // Supports both local (env-based) and gateway (header-based) credential modes
 
 import { createServer, IncomingMessage, ServerResponse, Server as HttpServer } from 'node:http';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import {
-  CallToolRequestSchema,
-  ErrorCode,
-  ListResourcesRequestSchema,
-  ListToolsRequestSchema,
-  McpError,
-  ReadResourceRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-
 import { AutotaskService } from '../services/autotask.service.js';
 import { Logger } from '../utils/logger.js';
 import { McpServerConfig } from '../types/mcp.js';
@@ -164,52 +155,52 @@ export class AutotaskMcpServer {
     this.logger.info('Setting up MCP request handlers...');
 
     // List available resources
-    server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    server.setRequestHandler('resources/list', async () => {
       try {
         this.logger.debug('Handling list resources request');
         const resources = await resourceHandler.listResources();
         return { resources };
       } catch (error) {
         this.logger.error('Failed to list resources:', error);
-        throw new McpError(
-          ErrorCode.InternalError,
+        throw new ProtocolError(
+          ProtocolErrorCode.InternalError,
           `Failed to list resources: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
     });
 
     // Read a specific resource
-    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    server.setRequestHandler('resources/read', async (request) => {
       try {
         this.logger.debug(`Handling read resource request for: ${request.params.uri}`);
         const content = await resourceHandler.readResource(request.params.uri);
         return { contents: [content] };
       } catch (error) {
         this.logger.error(`Failed to read resource ${request.params.uri}:`, error);
-        throw new McpError(
-          ErrorCode.InternalError,
+        throw new ProtocolError(
+          ProtocolErrorCode.InternalError,
           `Failed to read resource: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
     });
 
     // List available tools
-    server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.setRequestHandler('tools/list', async () => {
       try {
         this.logger.debug('Handling list tools request');
         const tools = await toolHandler.listTools();
         return { tools };
       } catch (error) {
         this.logger.error('Failed to list tools:', error);
-        throw new McpError(
-          ErrorCode.InternalError,
+        throw new ProtocolError(
+          ProtocolErrorCode.InternalError,
           `Failed to list tools: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
     });
 
     // Call a tool
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler('tools/call', async (request) => {
       try {
         this.logger.debug(`Handling tool call: ${request.params.name}`);
         const result = await toolHandler.callTool(
@@ -222,8 +213,8 @@ export class AutotaskMcpServer {
         };
       } catch (error) {
         this.logger.error(`Failed to call tool ${request.params.name}:`, error);
-        throw new McpError(
-          ErrorCode.InternalError,
+        throw new ProtocolError(
+          ProtocolErrorCode.InternalError,
           `Failed to call tool: ${error instanceof Error ? error.message : 'Unknown error'}`
         );
       }
@@ -352,7 +343,7 @@ export class AutotaskMcpServer {
 
         // Stateless: create fresh server + transport for each request
         const server = this.createFreshServer(perRequestToolHandler, perRequestResourceHandler);
-        const transport = new StreamableHTTPServerTransport({
+        const transport = new NodeStreamableHTTPServerTransport({
           enableJsonResponse: true,
         });
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,3 +1,6 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/server";
+import type { Transport } from "@modelcontextprotocol/server";
+
 // Cloudflare Workers entry point for the Autotask MCP Server.
 //
 // Serves the full MCP server over the Streamable HTTP transport using the SDK's
@@ -24,9 +27,6 @@
 //
 // `tools/list` and `initialize` work without credentials; only `tools/call`
 // requires them.
-
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { AutotaskMcpServer } from './mcp/server.js';
 import { Logger } from './utils/logger.js';
 import {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,12 +1,12 @@
-import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/server";
-import type { Transport } from "@modelcontextprotocol/server";
-
 // Cloudflare Workers entry point for the Autotask MCP Server.
 //
-// Serves the full MCP server over the Streamable HTTP transport using the SDK's
-// Web Standard transport (Request/Response), which runs natively on Workers.
-// It reuses the exact same handler wiring as the stdio / Node HTTP entrypoints
-// via AutotaskMcpServer.createRequestServer(), so there is no second tool
+// Serves the full MCP server via the v2 SDK's createMcpHandler, whose
+// web-standard fetch face runs natively on Workers. Modern (2026-07-28
+// envelope) traffic is served natively; legacy 2025-era traffic is served by
+// the default stateless fallback — a fresh server per request, the same
+// per-request idiom this Worker has always used. It reuses the exact same
+// factory as the stdio / Node HTTP entrypoints via
+// AutotaskMcpServer.requestFactory(), so there is no second tool
 // implementation to maintain.
 //
 // The Autotask service layer talks to the REST API through AutotaskHttpClient,
@@ -27,12 +27,12 @@ import type { Transport } from "@modelcontextprotocol/server";
 //
 // `tools/list` and `initialize` work without credentials; only `tools/call`
 // requires them.
+import { createMcpHandler, type McpHttpHandler } from '@modelcontextprotocol/server';
 import { AutotaskMcpServer } from './mcp/server.js';
 import { Logger } from './utils/logger.js';
 import {
   getServerVersion,
   parseCredentialsFromHeaders,
-  type GatewayCredentials,
 } from './utils/config.js';
 import type { McpServerConfig } from './types/mcp.js';
 
@@ -116,6 +116,21 @@ function getAppServer(env: Env): AutotaskMcpServer {
   return appServer;
 }
 
+/**
+ * Build (once per isolate) the dual-era MCP handler over the shared factory.
+ * Per-request credential isolation happens inside the factory, which reads
+ * the gateway headers from each request via ctx.requestInfo.
+ */
+let mcpHandler: McpHttpHandler | undefined;
+function getMcpHandler(env: Env): McpHttpHandler {
+  if (!mcpHandler) {
+    mcpHandler = createMcpHandler(getAppServer(env).requestFactory(), {
+      legacy: 'stateless',
+    });
+  }
+  return mcpHandler;
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -139,7 +154,6 @@ export default {
     if (url.pathname === '/mcp') {
       const isGatewayMode = (env.AUTH_MODE ?? 'env') === 'gateway';
 
-      let credentials: GatewayCredentials | undefined;
       if (isGatewayMode) {
         const parsed = parseCredentialsFromHeaders(
           Object.fromEntries(request.headers) as Record<
@@ -159,28 +173,13 @@ export default {
             401
           );
         }
-        credentials = parsed;
       }
 
-      // Fresh server + transport per request (stateless). The handler factory
-      // (AutotaskMcpServer) is memoized per isolate; createRequestServer()
-      // produces an isolated server bound to the per-request credentials.
-      const server = getAppServer(env).createRequestServer(credentials);
-      // Omit `sessionIdGenerator` entirely (rather than passing `undefined`)
-      // to satisfy exactOptionalPropertyTypes; an absent generator yields the
-      // same stateless behavior.
-      const transport = new WebStandardStreamableHTTPServerTransport({
-        enableJsonResponse: true,
-      });
-      await server.connect(transport as unknown as Transport);
-
-      try {
-        const response = await transport.handleRequest(request);
-        return withCors(response);
-      } finally {
-        await transport.close();
-        await server.close();
-      }
+      // Dual-era serving; both eras get a fresh factory-built server per
+      // request. The factory reads the gateway credential headers from
+      // ctx.requestInfo, so per-tenant isolation is unchanged.
+      const response = await getMcpHandler(env).fetch(request);
+      return withCors(response);
     }
 
     return json({ error: 'Not found', endpoints: ['/mcp', '/health'] }, 404);

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,8 +1,8 @@
 // Tests for the Cloudflare Workers entrypoint.
 //
 // Drives the exported `fetch` handler directly with Web Standard Request objects
-// (available natively in Node 18+), exercising the same WebStandardStreamableHTTP
-// transport the Worker uses in production.
+// (available natively in Node 18+), exercising the same createMcpHandler
+// dual-era serving the Worker uses in production.
 
 import worker, { type Env } from '../src/worker.js';
 
@@ -10,6 +10,24 @@ const MCP_HEADERS = {
   Accept: 'application/json, text/event-stream',
   'Content-Type': 'application/json',
 };
+
+/**
+ * Parse a JSON-RPC response body that may arrive either as plain JSON or as
+ * an SSE stream. The v2 SDK's stateless legacy fallback answers 2025-era
+ * POSTs with `text/event-stream` (one `message` event per response) — the
+ * canonical Streamable HTTP shape every spec-conforming client accepts.
+ */
+async function mcpBody<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  const contentType = res.headers.get('content-type') ?? '';
+  if (contentType.includes('text/event-stream')) {
+    const dataLines = text.split('\n').filter((line) => line.startsWith('data:'));
+    const last = dataLines[dataLines.length - 1];
+    if (!last) throw new Error(`No data frame in SSE body: ${text}`);
+    return JSON.parse(last.slice('data:'.length).trim()) as T;
+  }
+  return JSON.parse(text) as T;
+}
 
 async function mcp(
   body: unknown,
@@ -63,9 +81,9 @@ describe('Cloudflare Worker entrypoint', () => {
       },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
+    const body = await mcpBody<{
       result?: { serverInfo?: { name?: string } };
-    };
+    }>(res);
     expect(body.result?.serverInfo?.name).toBe('autotask-mcp');
   });
 
@@ -77,9 +95,9 @@ describe('Cloudflare Worker entrypoint', () => {
       params: {},
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
+    const body = await mcpBody<{
       result?: { tools?: { name: string }[] };
-    };
+    }>(res);
     const names = (body.result?.tools ?? []).map((t) => t.name);
     expect(names).toContain('autotask_test_connection');
     expect(names).toContain('autotask_search_companies');
@@ -94,9 +112,9 @@ describe('Cloudflare Worker entrypoint', () => {
       params: { name: 'autotask_test_connection', arguments: {} },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
+    const body = await mcpBody<{
       result?: { isError?: boolean; content?: { text?: string }[] };
-    };
+    }>(res);
     expect(body.result?.isError).toBe(true);
   });
 
@@ -129,9 +147,9 @@ describe('Cloudflare Worker entrypoint', () => {
       }
     );
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
+    const body = await mcpBody<{
       result?: { tools?: { name: string }[] };
-    };
+    }>(res);
     expect((body.result?.tools ?? []).length).toBeGreaterThan(10);
   });
 });


### PR DESCRIPTION
Closes #218 (pilot #1 of the MCP 2026-07-28 spec migration).

Migrates from `@modelcontextprotocol/sdk` v1 to the split v2 beta (`server`/`node` @ 2.0.0-beta.5). One shared `McpServerFactory` now backs all three entrypoints — stdio (`serveStdio`), Node HTTP (`createMcpHandler` + `toNodeHandler`), and the Worker (`createMcpHandler`, per-isolate memoized). `legacy: 'stateless'` (the default) keeps serving 2025-era `initialize`-handshake clients through the 12-month deprecation window while natively speaking the 2026-07-28 envelope protocol.

**Acceptance artifact** — `scripts/smoke-dual-era.mjs`: the same endpoint answers a hand-crafted legacy handshake sequence and a modern `@modelcontextprotocol/client` v2 session; both list the identical 98 tools (names asserted, no drift). `tool.definitions.ts` is byte-identical to main; gateway credential-header contract unchanged (401 gate stays in the HTTP layer, factory binds creds per request from `ctx.requestInfo`).

Local verification: jest 166/166, lint clean, stdio legacy handshake check green.

**Draft until:** review + fleet-rollout decision on v2 stable (this intentionally ships on the beta SDK as a pilot). Gotchas feeding the fleet playbook are in the issue thread repo docs to follow.