### PR TITLE
fix(security): enforce gateway S2S verification (gateway#377 parity)

### DIFF
--- a/src/mcp/s2s-verify.ts
+++ b/src/mcp/s2s-verify.ts
@@ -1,0 +1,43 @@
+/**
+ * Verifies the conduit gateway's service-to-service auth header
+ * (gateway#377 parity — closes the confused-deputy gap where a compromised
+ * sibling sidecar in the shared ACA environment could otherwise impersonate
+ * the gateway to this container).
+ *
+ * This is a near-verbatim port of conduit's `verifyS2sHeader`
+ * (src/proxy/s2s.ts) — intentionally unchanged logic, ported once and kept
+ * in sync. `secret` is treated as an opaque value: since gateway#377
+ * Finding B, the gateway derives a per-vendor subkey from its master
+ * secret and this container is provisioned (via CONDUIT_S2S_SECRET) with
+ * only its own derived value, never the raw master — a sibling sidecar
+ * holds a DIFFERENT derived value and cannot forge a header that verifies
+ * here. This function doesn't need to know that; it just checks whatever
+ * secret it's handed.
+ *
+ * Empty secret => always returns false. The caller is expected to treat an
+ * empty CONDUIT_S2S_SECRET as "S2S enforcement disabled" (dark-by-default,
+ * matches the dormant/pre-provisioning state) rather than calling this at
+ * all — see the enforcement check at the call site.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** Request header carrying the S2S proof. Node lowercases incoming header names. */
+export const S2S_HEADER = "x-gateway-s2s";
+
+const HEADER_VALUE_RE = /^t=(\d{1,15}),v1=([0-9a-f]{64})$/;
+
+export function verifyS2sHeader(
+  headerValue: string | undefined,
+  secret: string,
+  maxSkewSeconds = 300
+): boolean {
+  if (!secret || !headerValue) return false;
+  const match = HEADER_VALUE_RE.exec(headerValue);
+  if (!match) return false;
+  const t = Number(match[1]);
+  if (!Number.isSafeInteger(t)) return false;
+  if (Math.abs(Math.floor(Date.now() / 1000) - t) > maxSkewSeconds) return false;
+  const expected = createHmac("sha256", secret).update(`t=${t}`).digest();
+  const provided = Buffer.from(match[2], "hex");
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,6 +26,7 @@ import { EnvironmentConfig, parseCredentialsFromHeaders, GatewayCredentials, get
 import { AutotaskResourceHandler } from '../handlers/resource.handler.js';
 import { AutotaskToolHandler } from '../handlers/tool.handler.js';
 import { registerPromptHandlers } from './prompts.js';
+import { verifyS2sHeader, S2S_HEADER } from './s2s-verify.js';
 
 export class AutotaskMcpServer {
   private config: McpServerConfig;
@@ -353,6 +354,28 @@ export class AutotaskMcpServer {
       // MCP endpoint — dual-era handler (fresh factory-built server per
       // request in both eras; nothing is shared between requests)
       if (url.pathname === '/mcp') {
+        // Gateway S2S verification (gateway#377 parity). Runs before any
+        // credential extraction — see src/mcp/s2s-verify.ts. Empty secret
+        // means S2S enforcement isn't provisioned for this vendor yet, so
+        // we don't call verifyS2sHeader at all (dark-by-default).
+        const s2sSecret = process.env.CONDUIT_S2S_SECRET || '';
+        if (s2sSecret) {
+          const s2sHeader = req.headers[S2S_HEADER] as string | undefined;
+          if (!verifyS2sHeader(s2sHeader, s2sSecret)) {
+            this.logger.warn('Rejected request with missing/invalid gateway S2S header');
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              jsonrpc: '2.0',
+              error: {
+                code: -32001,
+                message: 'Unauthorized: missing or invalid gateway S2S authentication header',
+              },
+              id: null,
+            }));
+            return;
+          }
+        }
+
         // In gateway mode, require the injected credential headers up front.
         // Falling through to the env-configured handlers would serve the
         // server operator's tenant data to whoever sent the unauthenticated

--- a/tests/s2s-verify.test.ts
+++ b/tests/s2s-verify.test.ts
@@ -1,0 +1,59 @@
+import { createHmac } from 'node:crypto';
+import { verifyS2sHeader } from '../src/mcp/s2s-verify.js';
+
+function deriveRecipientSubkey(masterSecret: string, slug: string): string {
+  return createHmac('sha256', masterSecret).update(`s2s-recipient:${slug}`).digest('hex');
+}
+function mintHeader(secret: string, unixSeconds: number): string {
+  const message = `t=${unixSeconds}`;
+  const hex = createHmac('sha256', secret).update(message).digest('hex');
+  return `${message},v1=${hex}`;
+}
+
+describe('verifyS2sHeader', () => {
+  const MASTER = 'test-master-secret-do-not-use-in-prod';
+  const ownSubkey = deriveRecipientSubkey(MASTER, 'autotask');
+  const siblingSubkey = deriveRecipientSubkey(MASTER, 'action1');
+  // Fixed, frozen clock so skew-window boundary tests are deterministic —
+  // without this, a real clock tick between minting a header and verifying
+  // it can shave a second off the intended skew, flaking the boundary cases.
+  const NOW = 1_800_000_000;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW * 1000);
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("accepts a header minted with this vendor's own derived subkey", () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, NOW), ownSubkey)).toBe(true);
+  });
+  it('REJECTS a header minted for a different vendor\'s derived subkey (recipient-binding proof)', () => {
+    expect(verifyS2sHeader(mintHeader(siblingSubkey, NOW), ownSubkey)).toBe(false);
+  });
+  it('rejects a stale timestamp outside the skew window', () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, NOW - 301), ownSubkey)).toBe(false);
+  });
+  it('rejects a future timestamp outside the skew window', () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, NOW + 301), ownSubkey)).toBe(false);
+  });
+  it('accepts a timestamp at the edge of the skew window', () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, NOW - 300), ownSubkey)).toBe(true);
+  });
+  it('rejects a malformed header value', () => {
+    expect(verifyS2sHeader('not-a-valid-header', ownSubkey)).toBe(false);
+  });
+  it('rejects a missing header', () => {
+    expect(verifyS2sHeader(undefined, ownSubkey)).toBe(false);
+  });
+  it('rejects when the secret is empty (dark-by-default guarantee)', () => {
+    expect(verifyS2sHeader(mintHeader(ownSubkey, NOW), '')).toBe(false);
+  });
+  it('rejects a tampered signature', () => {
+    const header = mintHeader(ownSubkey, NOW);
+    const tampered = header.slice(0, -1) + (header.endsWith('0') ? '1' : '0');
+    expect(verifyS2sHeader(tampered, ownSubkey)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Enforces the conduit gateway's service-to-service (S2S) auth header on the `/mcp` endpoint, before any gateway credential extraction happens.

This closes the confused-deputy gap where a compromised sibling sidecar in the shared ACA environment could otherwise impersonate the gateway to this container (gateway#377 parity, Finding B). `src/mcp/s2s-verify.ts` is a byte-for-byte, near-verbatim port of conduit's `verifyS2sHeader` (`src/proxy/s2s.ts`) — same HMAC-over-timestamp scheme, same skew window, same timing-safe comparison.

This is a mechanical, fleet-wide rollout wave. The pattern (module + guard placement + test suite) was already live-validated end-to-end on cipp-mcp#80 (class-method archetype — same shape as this repo) and blackpoint-mcp#54 (no-explicit-route-check archetype). This PR replicates that validated pattern into `autotask-mcp` without any design changes.

## Where the guard was inserted

`src/mcp/server.ts`, `AutotaskMcpServer.startHttpTransport()`, at the very top of the `if (url.pathname === '/mcp')` block (around line 355) — before the gateway-mode check and before `parseCredentialsFromHeaders()` is ever called. Verified by reading the current file directly (not assumed from a template); `src/index.ts` is bootstrap-only and was not touched.

Behavior:
- `CONDUIT_S2S_SECRET` empty/unset → S2S enforcement is dark-by-default (not yet provisioned for this vendor); `verifyS2sHeader` is never called, existing behavior is unchanged.
- `CONDUIT_S2S_SECRET` set → the `x-gateway-s2s` header must be present and verify (HMAC match + timestamp within 300s skew) or the request is rejected with 401 before any credential extraction occurs.

## Out of scope

This repo also ships `src/worker.ts` — a separate Cloudflare Worker with its own independent credential check. It was already assessed in a prior investigation this session as DEAD / not gateway-routed. It is explicitly **out of scope** for this PR and was not touched — noted here rather than silently skipped.

## Test results

- `npx tsc --noEmit`: clean
- `npm run build`: clean
- `npm test` (Jest, via `tests/s2s-verify.test.ts`, this repo's top-level test convention): all tests passing — 175/175 across all 16 test suites (9 new cases in `s2s-verify.test.ts`: own-subkey accept, sibling-subkey/recipient-binding reject, stale/future timestamp reject, skew-boundary accept, malformed/missing header reject, empty-secret dark-by-default reject, tampered-signature reject; plus the 15 pre-existing suites, all still green).
- The skew-window boundary tests use `jest.setSystemTime` to freeze the clock for the duration of each test, rather than capturing `Date.now()` once and reusing it — the latter races the real clock (a tick across a wall-clock second boundary between minting and verifying can shave a second off the intended skew and flip the +301s "future timestamp" case from reject to accept). This was caught during validation and fixed before this PR was opened.
- A benign "worker process failed to exit gracefully" warning appears at the end of the Jest run; it's pre-existing in this repo (several existing suites, e.g. `http-cors.test.ts`, spin up real HTTP listeners) and unrelated to this change — all 175 tests still pass, exit code 0.
- **CI**: verified directly by reading this repo's workflows — `test.yml` triggers on `pull_request` (to `main`/`next`/`next-major`/`beta`/`alpha`) and has an explicit "Run tests" step (`npm test`). **This PR's new tests ARE CI-gated** and will run automatically once this PR opens against `main`.
- No live smoke test was needed — this repo's actual `startHttpTransport()` structure matched the expected class-method archetype exactly (verified by reading the file before editing), so no workaround was required.

## Review

Do not merge without Walter + boss review — auth surface, heightened-review-and-narrate tier.
