### PR TITLE
feat(contracts): add contract management tools (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
 
 ### Added
 
+- **Contract management tools** ([#237](https://github.com/wyre-technology/autotask-mcp/issues/237)). Contract coverage now spans the full read/report/create lifecycle:
+  - `autotask_get_contract` — single contract header by ID (the service method existed but was never exposed as a tool).
+  - `autotask_search_contracts` gained `contractType` and `endDateFrom`/`endDateTo` filters alongside the existing name/company/status ones.
+  - `autotask_list_expiring_contracts` — dedicated expiring/expired-contracts report: contracts whose end date falls within the next `daysAhead` days (default 60), optionally including already-lapsed contracts (`includeExpired`), scoped to one company or the whole org.
+  - `autotask_create_contracts_bulk` — create up to 50 contract shells (header records, no service lines) in one call, e.g. onboarding a customer with several location-based contracts. Shells POST sequentially (Autotask has no batch endpoint and bursts risk 429 thresholds); a failed shell doesn't abort the batch — each item reports its own `success`/`id`/`error` so callers can retry just the failures.
+  - The `financial` tool category now lists every contract tool (the previously-added write tools were missing from it), and the intent router recognizes "expiring/renewing contract" phrasing.
+
 - **Dual-era smoke test** (`scripts/smoke-dual-era.mjs`): boots the built HTTP server with dummy credentials and proves a hand-crafted 2025-era JSON-RPC client (classic `initialize` → `notifications/initialized` → `tools/list`) and a modern `@modelcontextprotocol/client@2` StreamableHTTP session both see the identical non-empty tool surface. Exits non-zero on any failure.
 
 - **Interactive ticket card via MCP Apps (SEP-1865).** `autotask_get_ticket_details` results now render as an interactive card in MCP Apps hosts (Claude Desktop/web, and other hosts advertising the `io.modelcontextprotocol/ui` extension), instead of a wall of JSON. The card shows status/priority/queue as human-readable labels, company and assignee names, dates, and recent notes — and includes a working "Add note" round-trip that calls `autotask_create_ticket_note` from inside the card. Non-App hosts are unaffected: the tool's JSON payload is unchanged apart from a new `_card` field.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,10 @@ Workflow defaults (commits, changelog, memory) come from the global `~/.claude/C
 
 ## Learnings
 <!-- Record non-obvious discoveries as dated entries: "## Learnings - YYYY-MM-DD" -->
+
+## Learnings - 2026-08-10
+
+- Issue asks can be stale: #237 claimed "no Contracts tools" but search/create/update already existed (added after the issue was filed). Always scope against `src/handlers/tool.definitions.ts` before implementing "missing" tools.
+- `TOOL_CATEGORIES` in `tool.definitions.ts` is hand-maintained and drifts from `TOOL_DEFINITIONS` — nothing enforces parity (the contract write tools were absent from `financial` for months). A parity test would prevent this class of drift.
+- The intent router's entity regexes (`tool.handler.ts` `routeIntent`) matched only singular nouns (`\bcontract\b` missed "contracts") until #238 added `s?`; check the other entity branches if router misses are reported.
+- `exactOptionalPropertyTypes` is on: optional result-object fields need explicit `| undefined` in their type when assigned from possibly-undefined sources.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Give your AI assistant direct access to Autotask.** Search tickets, create time entries, look up companies, manage projects — all through natural language. No more copy-pasting between browser tabs and chat windows.
 
-This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that connects Claude (or any MCP-compatible AI) to your Autotask PSA environment. Your AI assistant gets 39 tools covering the operations MSP teams use daily: ticket triage, time logging, company lookups, project management, billing review, and more.
+This is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that connects Claude (or any MCP-compatible AI) to your Autotask PSA environment. Your AI assistant gets 101 tools covering the operations MSP teams use daily: ticket triage, time logging, company lookups, project management, billing review, and more.
 
 If you run an MSP on Autotask and you're tired of the context-switching tax, this is for you.
 
@@ -56,7 +56,7 @@ See [Installation](#installation) for Docker and from-source methods.
 
 - **🔌 MCP Protocol Compliance**: Full support for MCP resources and tools
 - **🎴 Interactive Ticket Card (MCP Apps)**: `autotask_get_ticket_details` renders as an interactive card in MCP Apps hosts (Claude Desktop/web) with an in-card "Add note" round-trip; neutral theme by default, brandable via `MCP_BRAND_*` env vars; plain-JSON behavior is unchanged in other hosts
-- **🛠️ Comprehensive API Coverage**: 39 tools spanning companies, contacts, tickets, projects, billing items, time entries, notes, attachments, and more
+- **🛠️ Comprehensive API Coverage**: 101 tools spanning companies, contacts, tickets, projects, billing items, time entries, notes, attachments, and more
 - **🔍 Advanced Search**: Powerful search capabilities with filters across all entities
 - **📝 CRUD Operations**: Create, read, update operations for core Autotask entities
 - **🔄 ID-to-Name Mapping**: Automatic resolution of company and resource IDs to human-readable names
@@ -317,7 +317,7 @@ Resources provide read-only access to Autotask data:
 
 ### Tools
 
-The server provides 39 tools for interacting with Autotask:
+The server provides 101 tools for interacting with Autotask:
 
 #### Company Operations
 - `autotask_search_companies` - Search companies with filters
@@ -362,7 +362,14 @@ The server provides 39 tools for interacting with Autotask:
 - `autotask_get_expense_report` / `autotask_search_expense_reports` / `autotask_create_expense_report`
 - `autotask_get_quote` / `autotask_search_quotes` / `autotask_create_quote`
 - `autotask_search_invoices` - Search invoices
-- `autotask_search_contracts` - Search contracts
+
+#### Contract Operations
+- `autotask_search_contracts` - Search contracts (name, company, status, type, end-date range)
+- `autotask_get_contract` - Get a single contract by ID
+- `autotask_list_expiring_contracts` - Expiring/expired contracts report (next N days, per company or org-wide)
+- `autotask_create_contract` / `autotask_create_contracts_bulk` - Create contract shells, one or many
+- `autotask_update_contract` - Update a contract (e.g. extend/renew end date)
+- `autotask_create_contract_service` / `autotask_update_contract_service` - Manage contract service lines
 
 #### Configuration Items
 - `autotask_search_configuration_items` - Search configuration items (assets)

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -4,6 +4,45 @@
 import { McpTool } from './tool.handler.js';
 import { TICKET_CARD_META } from './card.builder.js';
 
+// Contract shell fields shared by autotask_create_contract and
+// autotask_create_contracts_bulk (issue #237). Field names match the
+// Autotask REST API exactly.
+const CONTRACT_SHELL_PROPERTIES = {
+  companyID: { type: 'number', description: 'Company ID the contract is associated with' },
+  contractName: { type: 'string', description: 'Contract name' },
+  contractType: { type: 'number', description: 'Contract type picklist ID' },
+  contractCategory: { type: 'number', description: 'Contract category picklist ID' },
+  startDate: { type: 'string', description: 'Contract start date (ISO YYYY-MM-DD)' },
+  endDate: { type: 'string', description: 'Contract end date (ISO YYYY-MM-DD)' },
+  contactID: { type: 'number', description: 'Primary contact ID for the contract' },
+  contractNumber: { type: 'string', description: 'External-facing contract number' },
+  contractPeriodType: { type: 'number', description: 'Period type picklist ID' },
+  description: { type: 'string', description: 'Contract description / notes' },
+  estimatedCost: { type: 'number', description: 'Estimated cost' },
+  estimatedHours: { type: 'number', description: 'Estimated hours' },
+  estimatedRevenue: { type: 'number', description: 'Estimated revenue' },
+  setupFee: { type: 'number', description: 'Setup fee amount' },
+  overageBillingRate: { type: 'number', description: 'Overage billing rate' },
+  serviceLevelAgreementID: { type: 'number', description: 'SLA ID' },
+  purchaseOrderNumber: { type: 'string', description: 'Customer purchase order number' },
+  opportunityID: { type: 'number', description: 'Originating opportunity ID' },
+  billingPreference: { type: 'number', description: 'Billing preference picklist ID' },
+  billToCompanyID: { type: 'number', description: 'Bill-to company ID' },
+  billToCompanyContactID: { type: 'number', description: 'Bill-to contact ID' },
+  exclusionContractID: { type: 'number', description: 'Exclusion contract ID' },
+  isDefaultContract: { type: 'boolean', description: 'Whether this is the default contract for the company' },
+  internalCurrencySetupFee: { type: 'number', description: 'Setup fee in internal currency' },
+  internalCurrencyOverageBillingRate: { type: 'number', description: 'Overage rate in internal currency' },
+  organizationalLevelAssociationID: { type: 'number', description: 'Org level association ID' },
+  contractExclusionSetID: { type: 'number', description: 'Contract exclusion set ID' },
+  renewedContractID: { type: 'number', description: 'ID of the contract this renewed' },
+  setupFeeBillingCodeID: { type: 'number', description: 'Billing code ID for the setup fee' },
+  status: { type: 'number', description: 'Contract status (1=In Effect, 0=Inactive)' },
+  timeReportingRequiresStartAndStopTimes: { type: 'number', description: 'Whether time entries require start/stop times' }
+};
+
+const CONTRACT_SHELL_REQUIRED = ['companyID', 'contractName', 'contractType', 'contractCategory', 'startDate', 'endDate'];
+
 export const TOOL_DEFINITIONS: McpTool[] = [
   // Connection testing
   {
@@ -2157,9 +2196,68 @@ export const TOOL_DEFINITIONS: McpTool[] = [
           type: 'number',
           description: 'Filter by contract status (1=In Effect, 3=Terminated)'
         },
+        contractType: {
+          type: 'number',
+          description: 'Filter by contract type picklist ID'
+        },
+        endDateFrom: {
+          type: 'string',
+          description: 'Only contracts ending on or after this date (ISO YYYY-MM-DD)'
+        },
+        endDateTo: {
+          type: 'string',
+          description: 'Only contracts ending on or before this date (ISO YYYY-MM-DD)'
+        },
         pageSize: {
           type: 'number',
           description: 'Number of results to return (default: 25, max: 500)',
+          minimum: 1,
+          maximum: 500
+        }
+      },
+      required: []
+    }
+  },
+  {
+    name: 'autotask_get_contract',
+    description: 'Get a single contract by ID (header fields only, no service lines)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Contract ID'
+        }
+      },
+      required: ['id']
+    }
+  },
+  {
+    name: 'autotask_list_expiring_contracts',
+    description: 'List contracts whose end date falls within the next N days (expiring-contracts report). Optionally include already-expired contracts, and scope to one company or the whole org.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        daysAhead: {
+          type: 'number',
+          description: 'Look-ahead window in days (default: 60)',
+          minimum: 0
+        },
+        companyID: {
+          type: 'number',
+          description: 'Limit the report to one company (omit for the whole org)'
+        },
+        includeExpired: {
+          type: 'boolean',
+          description: 'Also include contracts whose end date is already in the past (default: false)'
+        },
+        status: {
+          type: 'number',
+          description: 'Filter by contract status (1=In Effect, 3=Terminated)'
+        },
+        pageSize: {
+          type: 'number',
+          description: 'Number of results to return (default: 100, max: 500)',
           minimum: 1,
           maximum: 500
         }
@@ -2923,40 +3021,29 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     description: 'Create a new Contract in Autotask. Field names match the Autotask REST API exactly. status: 1=In Effect, 0=Inactive. Dates are ISO format (YYYY-MM-DD).',
     inputSchema: {
       type: 'object',
+      properties: CONTRACT_SHELL_PROPERTIES,
+      required: CONTRACT_SHELL_REQUIRED
+    }
+  },
+  {
+    name: 'autotask_create_contracts_bulk',
+    description: 'Create multiple contract shells (header records, no service lines) in one call — e.g. onboarding a customer with several location-based contracts. Shells are created one at a time; a failure on one shell does not stop the rest, and each item reports its own success or error.',
+    inputSchema: {
+      type: 'object',
       properties: {
-        companyID: { type: 'number', description: 'Company ID the contract is associated with' },
-        contractName: { type: 'string', description: 'Contract name' },
-        contractType: { type: 'number', description: 'Contract type picklist ID' },
-        contractCategory: { type: 'number', description: 'Contract category picklist ID' },
-        startDate: { type: 'string', description: 'Contract start date (ISO YYYY-MM-DD)' },
-        endDate: { type: 'string', description: 'Contract end date (ISO YYYY-MM-DD)' },
-        contactID: { type: 'number', description: 'Primary contact ID for the contract' },
-        contractNumber: { type: 'string', description: 'External-facing contract number' },
-        contractPeriodType: { type: 'number', description: 'Period type picklist ID' },
-        description: { type: 'string', description: 'Contract description / notes' },
-        estimatedCost: { type: 'number', description: 'Estimated cost' },
-        estimatedHours: { type: 'number', description: 'Estimated hours' },
-        estimatedRevenue: { type: 'number', description: 'Estimated revenue' },
-        setupFee: { type: 'number', description: 'Setup fee amount' },
-        overageBillingRate: { type: 'number', description: 'Overage billing rate' },
-        serviceLevelAgreementID: { type: 'number', description: 'SLA ID' },
-        purchaseOrderNumber: { type: 'string', description: 'Customer purchase order number' },
-        opportunityID: { type: 'number', description: 'Originating opportunity ID' },
-        billingPreference: { type: 'number', description: 'Billing preference picklist ID' },
-        billToCompanyID: { type: 'number', description: 'Bill-to company ID' },
-        billToCompanyContactID: { type: 'number', description: 'Bill-to contact ID' },
-        exclusionContractID: { type: 'number', description: 'Exclusion contract ID' },
-        isDefaultContract: { type: 'boolean', description: 'Whether this is the default contract for the company' },
-        internalCurrencySetupFee: { type: 'number', description: 'Setup fee in internal currency' },
-        internalCurrencyOverageBillingRate: { type: 'number', description: 'Overage rate in internal currency' },
-        organizationalLevelAssociationID: { type: 'number', description: 'Org level association ID' },
-        contractExclusionSetID: { type: 'number', description: 'Contract exclusion set ID' },
-        renewedContractID: { type: 'number', description: 'ID of the contract this renewed' },
-        setupFeeBillingCodeID: { type: 'number', description: 'Billing code ID for the setup fee' },
-        status: { type: 'number', description: 'Contract status (1=In Effect, 0=Inactive)' },
-        timeReportingRequiresStartAndStopTimes: { type: 'number', description: 'Whether time entries require start/stop times' }
+        contracts: {
+          type: 'array',
+          description: 'Contract shells to create, in order. Same fields as autotask_create_contract.',
+          minItems: 1,
+          maxItems: 50,
+          items: {
+            type: 'object',
+            properties: CONTRACT_SHELL_PROPERTIES,
+            required: CONTRACT_SHELL_REQUIRED
+          }
+        }
       },
-      required: ['companyID', 'contractName', 'contractType', 'contractCategory', 'startDate', 'endDate']
+      required: ['contracts']
     }
   },
   {
@@ -3096,7 +3183,7 @@ export const TOOL_CATEGORIES: Record<string, { description: string; tools: strin
   },
   financial: {
     description: 'Quotes, quote items, opportunities, invoices, and contracts',
-    tools: ['autotask_get_quote', 'autotask_search_quotes', 'autotask_create_quote', 'autotask_get_quote_item', 'autotask_search_quote_items', 'autotask_create_quote_item', 'autotask_update_quote_item', 'autotask_delete_quote_item', 'autotask_get_opportunity', 'autotask_search_opportunities', 'autotask_create_opportunity', 'autotask_search_invoices', 'autotask_search_contracts']
+    tools: ['autotask_get_quote', 'autotask_search_quotes', 'autotask_create_quote', 'autotask_get_quote_item', 'autotask_search_quote_items', 'autotask_create_quote_item', 'autotask_update_quote_item', 'autotask_delete_quote_item', 'autotask_get_opportunity', 'autotask_search_opportunities', 'autotask_create_opportunity', 'autotask_search_invoices', 'autotask_search_contracts', 'autotask_get_contract', 'autotask_list_expiring_contracts', 'autotask_create_contract', 'autotask_create_contracts_bulk', 'autotask_update_contract', 'autotask_create_contract_service', 'autotask_update_contract_service']
   },
   products_and_services: {
     description: 'Products, services, and service bundles catalog',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -711,7 +711,15 @@ export class AutotaskToolHandler {
     }
 
     // Contract operations
-    if (/\b(?:contract|agreement)\b/.test(intent)) {
+    if (/\b(?:contract|agreement)s?\b/.test(intent) && /expir|renew|laps/.test(intent)) {
+      return {
+        suggestedTool: 'autotask_list_expiring_contracts',
+        suggestedParams: {},
+        description: 'List contracts expiring soon (or already expired)',
+        requiredParams: [],
+      };
+    }
+    if (/\b(?:contract|agreement)s?\b/.test(intent)) {
       return {
         suggestedTool: 'autotask_search_contracts',
         suggestedParams: {},
@@ -1037,6 +1045,18 @@ export class AutotaskToolHandler {
       // Contracts
       ['autotask_search_contracts', async (a) => {
         const r = await s.searchContracts(a); return { result: r, message: `Found ${r.length} contracts` };
+      }],
+      ['autotask_get_contract', async (a) => {
+        const r = await s.getContract(a.id); return { result: r, message: `Retrieved contract ${a.id}` };
+      }],
+      ['autotask_list_expiring_contracts', async (a) => {
+        const r = await s.listExpiringContracts(a);
+        return { result: r, message: `Found ${r.length} contracts with end dates within ${a.daysAhead ?? 60} days` };
+      }],
+      ['autotask_create_contracts_bulk', async (a) => {
+        const r = await s.createContracts(a.contracts);
+        const ok = r.filter((item) => item.success).length;
+        return { result: r, message: `Created ${ok}/${r.length} contracts` };
       }],
       ['autotask_create_contract', async (a) => {
         const id = await s.createContract(a); return { result: id, message: `Successfully created contract with ID: ${id}` };

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -981,8 +981,15 @@ export class AutotaskService {
 
       pushEq(filters, 'companyID', o.companyID);
       pushEq(filters, 'status', o.status);
+      pushEq(filters, 'contractType', o.contractType);
       if (o.searchTerm) {
         filters.push({ op: 'contains', field: 'contractName', value: o.searchTerm });
+      }
+      if (o.endDateFrom) {
+        filters.push({ op: 'gte', field: 'endDate', value: o.endDateFrom });
+      }
+      if (o.endDateTo) {
+        filters.push({ op: 'lte', field: 'endDate', value: o.endDateTo });
       }
       mergeFilterEscapeHatch(filters, options.filter);
 
@@ -994,6 +1001,44 @@ export class AutotaskService {
       );
     } catch (error) {
       this.logger.error('Failed to search contracts:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Expiring/expired contracts report (issue #237): contracts whose endDate
+   * falls within the next `daysAhead` days (default 60). With
+   * `includeExpired`, already-lapsed contracts are included too. Scope to one
+   * company via `companyID`, or the whole org by omitting it.
+   */
+  async listExpiringContracts(options: {
+    daysAhead?: number;
+    companyID?: number;
+    includeExpired?: boolean;
+    status?: number;
+    pageSize?: number;
+  } = {}): Promise<AutotaskContract[]> {
+    const http = await this.ensureClient();
+    try {
+      this.logger.debug('Listing expiring contracts with options:', options);
+      const daysAhead = options.daysAhead ?? 60;
+      const dayMs = 24 * 60 * 60 * 1000;
+      const isoDay = (d: Date) => d.toISOString().slice(0, 10);
+      const today = new Date();
+
+      const filters: QueryFilter[] = [
+        { op: 'lte', field: 'endDate', value: isoDay(new Date(today.getTime() + daysAhead * dayMs)) },
+      ];
+      if (!options.includeExpired) {
+        filters.push({ op: 'gte', field: 'endDate', value: isoDay(today) });
+      }
+      pushEq(filters, 'companyID', options.companyID);
+      pushEq(filters, 'status', options.status);
+
+      const pageSize = Math.min(options.pageSize || 100, 500);
+      return await http.query<AutotaskContract>('Contracts', filters, { maxRecords: pageSize });
+    } catch (error) {
+      this.logger.error('Failed to list expiring contracts:', error);
       throw error;
     }
   }
@@ -1013,6 +1058,43 @@ export class AutotaskService {
       this.logger.error('Failed to create contract:', error);
       throw error;
     }
+  }
+
+  /**
+   * Bulk contract-shell creation (issue #237). The Autotask REST API has no
+   * batch endpoint for Contracts, so shells are POSTed one at a time —
+   * sequentially, to stay under the per-integration API thresholds. A failed
+   * shell doesn't abort the batch; each item reports its own outcome so
+   * callers can retry just the failures.
+   */
+  async createContracts(contracts: Partial<AutotaskContract>[]): Promise<Array<{
+    index: number;
+    contractName?: string | undefined;
+    success: boolean;
+    id?: number | undefined;
+    error?: string | undefined;
+  }>> {
+    const results: Array<{
+      index: number;
+      contractName?: string | undefined;
+      success: boolean;
+      id?: number | undefined;
+      error?: string | undefined;
+    }> = [];
+    for (const [index, contract] of contracts.entries()) {
+      try {
+        const id = await this.createContract(contract);
+        results.push({ index, contractName: contract.contractName, success: true, id });
+      } catch (error) {
+        results.push({
+          index,
+          contractName: contract.contractName,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return results;
   }
 
   async updateContract(id: number, updates: Partial<AutotaskContract>): Promise<void> {

--- a/tests/autotask-service.test.ts
+++ b/tests/autotask-service.test.ts
@@ -864,6 +864,90 @@ describe('AutotaskService', () => {
       expect(capture().filter).toEqual(MATCH_ALL);
     });
 
+    // ---- Contract management tools (issue #237) ----
+
+    test('searchContracts translates contractType and endDate range', async () => {
+      const capture = captureFilter('Contracts');
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      await service.searchContracts({
+        contractType: 7,
+        endDateFrom: '2026-01-01',
+        endDateTo: '2026-12-31',
+      } as any);
+      const body = capture();
+      expect(body.filter).toContainEqual({ op: 'eq', field: 'contractType', value: 7 });
+      expect(body.filter).toContainEqual({ op: 'gte', field: 'endDate', value: '2026-01-01' });
+      expect(body.filter).toContainEqual({ op: 'lte', field: 'endDate', value: '2026-12-31' });
+    });
+
+    // Freeze only Date (not timers — AbortSignal.timeout and async plumbing
+    // must keep running) so the expiring-window math is deterministic.
+    const withFrozenDate = async (iso: string, fn: () => Promise<void>) => {
+      jest.useFakeTimers({
+        now: new Date(iso),
+        doNotFake: [
+          'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
+          'setImmediate', 'clearImmediate', 'queueMicrotask',
+          'nextTick', 'performance',
+        ],
+      });
+      try {
+        await fn();
+      } finally {
+        jest.useRealTimers();
+      }
+    };
+
+    test('listExpiringContracts queries the endDate window [today, today+daysAhead]', async () => {
+      await withFrozenDate('2026-08-10T12:00:00Z', async () => {
+        const capture = captureFilter('Contracts');
+        const service = new AutotaskService(configWithUrl, mockLogger);
+        await service.listExpiringContracts({ daysAhead: 30 });
+        const body = capture();
+        expect(body.filter).toContainEqual({ op: 'gte', field: 'endDate', value: '2026-08-10' });
+        expect(body.filter).toContainEqual({ op: 'lte', field: 'endDate', value: '2026-09-09' });
+      });
+    });
+
+    test('listExpiringContracts with includeExpired drops the lower bound and scopes by company', async () => {
+      await withFrozenDate('2026-08-10T12:00:00Z', async () => {
+        const capture = captureFilter('Contracts');
+        const service = new AutotaskService(configWithUrl, mockLogger);
+        await service.listExpiringContracts({ daysAhead: 14, includeExpired: true, companyID: 77 });
+        const body = capture();
+        expect(body.filter).toContainEqual({ op: 'eq', field: 'companyID', value: 77 });
+        expect(body.filter).toContainEqual({ op: 'lte', field: 'endDate', value: '2026-08-24' });
+        expect(body.filter).not.toContainEqual(
+          expect.objectContaining({ op: 'gte', field: 'endDate' })
+        );
+      });
+    });
+
+    test('createContracts creates each shell and continues past per-item failures', async () => {
+      let postCount = 0;
+      fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+        const url = typeof input === 'string' ? input : (input as URL).toString();
+        const method = (init?.method || 'GET').toUpperCase();
+        if (method === 'POST' && url === `${BASE}/Contracts`) {
+          postCount++;
+          if (postCount === 1) return jsonResponse({ errors: ['boom'] }, 500);
+          return jsonResponse({ itemId: 901 });
+        }
+        throw new Error(`unexpected ${method} ${url}`);
+      });
+
+      const service = new AutotaskService(configWithUrl, mockLogger);
+      const results = await service.createContracts([
+        { companyID: 1, contractName: 'A', contractType: 7, contractCategory: 3, startDate: '2026-01-01', endDate: '2026-12-31' },
+        { companyID: 2, contractName: 'B', contractType: 7, contractCategory: 3, startDate: '2026-01-01', endDate: '2026-12-31' },
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]).toMatchObject({ index: 0, contractName: 'A', success: false });
+      expect(results[0].error).toBeTruthy();
+      expect(results[1]).toMatchObject({ index: 1, contractName: 'B', success: true, id: 901 });
+    });
+
     test('searchConfigurationItems translates companyID, isActive, productID, searchTerm', async () => {
       const capture = captureFilter('ConfigurationItems');
       const service = new AutotaskService(configWithUrl, mockLogger);

--- a/tests/contract-tools.test.ts
+++ b/tests/contract-tools.test.ts
@@ -1,0 +1,164 @@
+// Contract management tool surface tests (issue #237):
+// autotask_get_contract, extended autotask_search_contracts filters,
+// autotask_list_expiring_contracts, and autotask_create_contracts_bulk.
+
+jest.mock('autotask-node', () => ({
+  AutotaskClient: {
+    create: jest.fn().mockRejectedValue(new Error('Mock: Cannot connect to Autotask API'))
+  }
+}));
+
+import { TOOL_DEFINITIONS, TOOL_CATEGORIES } from '../src/handlers/tool.definitions';
+import { AutotaskToolHandler } from '../src/handlers/tool.handler';
+import { AutotaskService } from '../src/services/autotask.service';
+import { Logger } from '../src/utils/logger';
+import type { McpServerConfig } from '../src/types/mcp';
+
+const mockConfig: McpServerConfig = {
+  name: 'test-server',
+  version: '1.0.0',
+  autotask: {
+    username: 'test-username',
+    secret: 'test-secret',
+    integrationCode: 'test-integration-code'
+  }
+};
+
+const mockLogger = new Logger('error');
+
+const findTool = (name: string) => TOOL_DEFINITIONS.find(t => t.name === name);
+
+const contractShell = (overrides: Record<string, any> = {}) => ({
+  companyID: 1,
+  contractName: 'Managed Services',
+  contractType: 7,
+  contractCategory: 3,
+  startDate: '2026-01-01',
+  endDate: '2026-12-31',
+  ...overrides,
+});
+
+describe('contract tool definitions (issue #237)', () => {
+  test('autotask_get_contract exists and requires id', () => {
+    const tool = findTool('autotask_get_contract');
+    expect(tool).toBeDefined();
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.id.type).toBe('number');
+    expect(tool!.inputSchema.required).toEqual(['id']);
+  });
+
+  test('autotask_search_contracts exposes contractType and endDate range as optional filters', () => {
+    const tool = findTool('autotask_search_contracts');
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.contractType.type).toBe('number');
+    expect(props.endDateFrom.type).toBe('string');
+    expect(props.endDateTo.type).toBe('string');
+    expect(tool!.inputSchema.required ?? []).toEqual([]);
+  });
+
+  test('autotask_list_expiring_contracts exists with daysAhead/companyID/includeExpired', () => {
+    const tool = findTool('autotask_list_expiring_contracts');
+    expect(tool).toBeDefined();
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.daysAhead.type).toBe('number');
+    expect(props.companyID.type).toBe('number');
+    expect(props.includeExpired.type).toBe('boolean');
+    expect(tool!.inputSchema.required ?? []).toEqual([]);
+  });
+
+  test('autotask_create_contracts_bulk requires a contracts array of contract shells', () => {
+    const tool = findTool('autotask_create_contracts_bulk');
+    expect(tool).toBeDefined();
+    const props = tool!.inputSchema.properties as Record<string, any>;
+    expect(props.contracts.type).toBe('array');
+    expect(props.contracts.items.required).toEqual(
+      expect.arrayContaining(['companyID', 'contractName', 'contractType', 'contractCategory', 'startDate', 'endDate'])
+    );
+    expect(tool!.inputSchema.required).toEqual(['contracts']);
+  });
+
+  test('financial category lists all contract tools', () => {
+    expect(TOOL_CATEGORIES.financial.tools).toEqual(
+      expect.arrayContaining([
+        'autotask_search_contracts',
+        'autotask_get_contract',
+        'autotask_list_expiring_contracts',
+        'autotask_create_contract',
+        'autotask_create_contracts_bulk',
+        'autotask_update_contract',
+        'autotask_create_contract_service',
+        'autotask_update_contract_service',
+      ])
+    );
+  });
+});
+
+describe('contract tool handlers (issue #237)', () => {
+  test('autotask_get_contract forwards id to service.getContract', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service, 'getContract')
+      .mockResolvedValue({ id: 55, contractName: 'Managed Services' } as any);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_get_contract', { id: 55 });
+    expect(spy).toHaveBeenCalledWith(55);
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('autotask_search_contracts forwards contractType and endDate range to the service', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service, 'searchContracts').mockResolvedValue([{ id: 1 }] as any);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    await handler.callTool('autotask_search_contracts', {
+      contractType: 7,
+      endDateFrom: '2026-01-01',
+      endDateTo: '2026-12-31',
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ contractType: 7, endDateFrom: '2026-01-01', endDateTo: '2026-12-31' })
+    );
+  });
+
+  test('autotask_list_expiring_contracts forwards options to service.listExpiringContracts', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service as any, 'listExpiringContracts')
+      .mockResolvedValue([{ id: 9, contractName: 'Expiring soon', endDate: '2026-08-20' }]);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_list_expiring_contracts', {
+      daysAhead: 45,
+      companyID: 9,
+      includeExpired: true,
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ daysAhead: 45, companyID: 9, includeExpired: true })
+    );
+    expect(result.isError).toBeFalsy();
+  });
+
+  test('autotask_create_contracts_bulk forwards shells and reports per-item results', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const spy = jest.spyOn(service as any, 'createContracts').mockResolvedValue([
+      { index: 0, contractName: 'A', success: true, id: 11 },
+      { index: 1, contractName: 'B', success: false, error: 'boom' },
+    ]);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_create_contracts_bulk', {
+      contracts: [contractShell({ contractName: 'A' }), contractShell({ contractName: 'B' })],
+    });
+    expect(spy).toHaveBeenCalledWith([
+      expect.objectContaining({ contractName: 'A' }),
+      expect.objectContaining({ contractName: 'B' }),
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('1/2');
+  });
+
+  test('router routes expiring-contract intent to autotask_list_expiring_contracts', async () => {
+    const service = new AutotaskService(mockConfig, mockLogger);
+    const handler = new AutotaskToolHandler(service, mockLogger);
+    const result = await handler.callTool('autotask_router', {
+      intent: 'show contracts expiring in the next 60 days',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.data.suggestedTool).toBe('autotask_list_expiring_contracts');
+  });
+});


### PR DESCRIPTION
Closes #237.

## What

Contract coverage now spans the full read / report / create lifecycle (issue #237 was filed against an older build with no contract tools; `search`/`create`/`update` already existed, so this PR fills the actual gaps):

| Ask in #237 | Delivered |
|---|---|
| Search by account, status, type, date range | `autotask_search_contracts` gains `contractType`, `endDateFrom`, `endDateTo` (name/company/status already existed) |
| Get single contract header | **New** `autotask_get_contract` — the service method existed but was never exposed as a tool |
| Expiring / expired contracts report | **New** `autotask_list_expiring_contracts` — end date within `daysAhead` days (default 60), `includeExpired` for already-lapsed contracts, scoped to one `companyID` or org-wide |
| Bulk contract-shell creation | **New** `autotask_create_contracts_bulk` — up to 50 shells per call |
| Update / renew (extend end date) | Already existed (`autotask_update_contract`) — unchanged |

## Design decisions

- **Bulk = sequential + continue-on-error.** Autotask has no batch endpoint for Contracts, and parallel bursts risk the per-integration 429 thresholds. Each shell reports its own `{index, contractName, success, id|error}` so a partial onboarding can be retried per-failure instead of aborting the batch (tool message reads `Created N/M contracts`).
- **The expiring report is a dedicated tool**, not a search recipe — per the issue's explicit ask. It's date-window driven only; pair with `status: 1` to get "in effect but lapsing" contracts.
- **Header fields only** on all read paths (no service lines), per the issue's "keep responses light".
- Contract shell schema is factored into one shared const used by both `autotask_create_contract` and the bulk tool's `items`, so the two can't drift.
- Targeted fixes riding along: the `financial` category was missing the previously-added contract write tools (now lists all 8), the intent router now matches plural "contracts" and routes expiring/renewal phrasing to the report tool, and README's stale "39 tools" is now 101.

## Verification

- 189/189 tests pass (17 suites), including new TDD coverage: filter-translation tests for the new search/report filters (via the existing `captureFilter` harness), bulk continue-on-error at the service level, and schema/handler-forwarding/router tests in `tests/contract-tools.test.ts`.
- `npm run build` clean; lint 0 errors with no new warnings.
- `scripts/smoke-dual-era.mjs` passes: both protocol eras serve the identical 101-tool surface, no drift.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->