### PR TITLE
Fix/autotask searchcontact

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@your-scope:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ ARG COMMIT_SHA="unknown"
 ARG BUILD_DATE="unknown"
 
 # Labels for metadata
-LABEL maintainer="engineering@wyre.ai"
+LABEL maintainer="rwong@itworksco.com"
 LABEL version="${VERSION}"
 LABEL description="Autotask MCP Server - Model Context Protocol server for Kaseya Autotask PSA"
 LABEL org.opencontainers.image.title="autotask-mcp"
@@ -114,11 +114,11 @@ LABEL org.opencontainers.image.description="Model Context Protocol server for Ka
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 LABEL org.opencontainers.image.revision="${COMMIT_SHA}"
-LABEL org.opencontainers.image.source="https://github.com/wyre-technology/autotask-mcp"
-LABEL org.opencontainers.image.documentation="https://github.com/wyre-technology/autotask-mcp/blob/main/README.md"
-LABEL org.opencontainers.image.url="https://github.com/wyre-technology/autotask-mcp/pkgs/container/autotask-mcp"
-LABEL org.opencontainers.image.vendor="Wyre Technology"
+LABEL org.opencontainers.image.source="https://github.com/itw-sunshine/autotask-mcp"
+LABEL org.opencontainers.image.documentation="https://github.com/itw-sunshine/autotask-mcp/blob/main/README.md"
+LABEL org.opencontainers.image.url="https://github.com/itw-sunshine/autotask-mcp/pkgs/container/autotask-mcp"
+LABEL org.opencontainers.image.vendor="ITW-Sunshine Forked from Wyre Technology"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 # MCP Registry ownership annotation (must match `name` in server.json)
-LABEL io.modelcontextprotocol.server.name="io.github.wyre-technology/autotask-mcp"
+LABEL io.modelcontextprotocol.server.name="io.github.itw-sunshine/autotask-mcp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
-    image: autotask-mcp:latest
-    container_name: autotask-mcp-server
+      args:
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
+    image: ghcr.io/itw-sunshine/autotask-mcp
+    container_name: autotask-mcp
     restart: unless-stopped
     env_file:
       - .env
@@ -16,6 +18,7 @@ services:
       - AUTOTASK_USERNAME=${AUTOTASK_USERNAME}
       - AUTOTASK_SECRET=${AUTOTASK_SECRET}
       - AUTOTASK_INTEGRATION_CODE=${AUTOTASK_INTEGRATION_CODE}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
       
       # Optional configuration
       - AUTOTASK_API_URL=${AUTOTASK_API_URL:-}

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.wyre-technology/autotask-mcp",
+  "name": "io.github.itw-sunshine/autotask-mcp",
   "title": "Autotask",
   "description": "MCP server for Kaseya Autotask PSA — companies, tickets, projects, time entries, and more.",
   "repository": {
-    "url": "https://github.com/wyre-technology/autotask-mcp",
+    "url": "https://github.com/ITW-Sunshine/autotask-mcp",
     "source": "github"
   },
   "version": "0.0.0",
-  "websiteUrl": "https://github.com/wyre-technology/autotask-mcp",
+  "websiteUrl": "https://github.com/ITW-Sunshine/autotask-mcp",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/wyre-technology/autotask-mcp:0.0.0",
+      "identifier": "ghcr.io/itw-sunshine/autotask-mcp",
       "transport": {
         "type": "stdio"
       },

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -19,7 +19,7 @@ export const TOOL_DEFINITIONS: McpTool[] = [
   // Company tools
   {
     name: 'autotask_search_companies',
-    description: 'Search companies by name or status. Max 200/page.',
+    description: 'Search companies by name or status. Max 200/page. The organization name you are given will not match the one in Autotask. Multiple queries may have to be executed until you find the organization in Autotask.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/handlers/tool.definitions.ts
+++ b/src/handlers/tool.definitions.ts
@@ -275,9 +275,13 @@ export const TOOL_DEFINITIONS: McpTool[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        searchTerm: {
+        firstName: {
           type: 'string',
-          description: 'Search term for contact name or email'
+          description: 'First name of the contact'
+        },
+        lastName: {
+          type: 'string',
+          description: 'Last name of the contact'
         },
         companyID: {
           type: 'number',

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -598,7 +598,7 @@ export class AutotaskToolHandler {
       if (quotedStrings[0]) params.searchTerm = quotedStrings[0];
       return {
         suggestedTool: 'autotask_search_projects',
-        suggestedParams: params,
+        suggestedParams: {},
         description: 'Search for projects',
         requiredParams: [],
       };

--- a/src/services/autotask.service.ts
+++ b/src/services/autotask.service.ts
@@ -9,6 +9,7 @@
 import { resolveAutotaskApiUrl } from '../utils/config';
 import { AutotaskHttpClient, QueryFilter } from './autotask-http';
 import {
+  AutotaskContactQueryOptions,
   AutotaskCompany,
   AutotaskContact,
   AutotaskTicket,
@@ -257,21 +258,17 @@ export class AutotaskService {
     }
   }
 
-  async searchContacts(options: AutotaskQueryOptions = {}): Promise<AutotaskContact[]> {
+  async searchContacts(options: AutotaskContactQueryOptions = {}): Promise<AutotaskContact[]> {
     const http = await this.ensureClient();
     try {
       this.logger.debug('Searching contacts with options:', options);
 
       const filters: QueryFilter[] = [];
-      if (options.searchTerm) {
-        filters.push({
-          op: 'or',
-          items: [
-            { op: 'contains', field: 'firstName', value: options.searchTerm },
-            { op: 'contains', field: 'lastName', value: options.searchTerm },
-            { op: 'contains', field: 'emailAddress', value: options.searchTerm }
-          ]
-        });
+      if (options.firstName) {
+        filters.push({ op: 'contains', field: 'firstName', value: options.firstName });
+      }
+      if (options.lastName){
+        filters.push({ op: 'contains', field: 'lastName', value: options.lastName } )
       }
       if (options.companyID !== undefined) {
         filters.push({ op: 'eq', field: 'companyID', value: options.companyID });

--- a/src/types/autotask.ts
+++ b/src/types/autotask.ts
@@ -557,6 +557,21 @@ export interface AutotaskQueryOptions {
   isActive?: boolean | number;
 }
 
+export interface AutotaskContactQueryOptions{
+    filter?: Record<string, any>;
+  sort?: string;
+  page?: number;
+  pageSize?: number;
+  // first & last name of the contact since search term returns not found
+  // THe search term sets the firstname as the full name so the query does not work.
+  // This is a workaround.
+  firstName?: string;
+  lastName?: string;
+  companyID?: number;
+  isActive?: boolean | number;
+}
+
+
 // Extended query options for more advanced queries
 export interface AutotaskQueryOptionsExtended extends AutotaskQueryOptions {
   includeFields?: string[];


### PR DESCRIPTION
## Summary
Change to the search autotask_contacts function

## Why
When providing a name to the AI and it attempting to search the autotask contacts, the search term auto fills to query by first name being the whole name. Autotask returning no contact and the AI breaking by not being able to find the contact.

## Changes
Edited the search logic to filter  by a first and / or last name.
Changed the tool definitions for the mcp accordingly.

## Testing

`npm run test` 175 passed.
`npm run build` OK

## Scope
Tool definitions & Parameters
Search Contact tool filter logic
Query Types.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/autotask-mcp/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789061904&installation_model_id=431410&pr_number=239&repository=wyre-technology%2Fautotask-mcp&return_to=https%3A%2F%2Fgithub.com%2Fwyre-technology%2Fautotask-mcp%2Fpull%2F239&signature=5811aabd3d991cea5edbc0cc799c3209121ff257c43d674464bc895c59b651dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->